### PR TITLE
Implement basic ScaledArray conversion semantics.

### DIFF
--- a/jax_scaled_arithmetics/core/datatype.py
+++ b/jax_scaled_arithmetics/core/datatype.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2023 Graphcore Ltd. All rights reserved.
 from dataclasses import dataclass
-from typing import Any, Optional, Union
+from typing import Any, Union
 
 import jax
 import numpy as np
@@ -35,7 +35,7 @@ class ScaledArray:
     """
 
     data: GenericArray
-    scale: Optional[GenericArray] = None
+    scale: GenericArray
 
     def __post_init__(self):
         assert isinstance(self.data, (jax.Array, np.ndarray))
@@ -71,8 +71,6 @@ class ScaledArray:
         """
         dtype = self.data.dtype if dtype is None else dtype
         data = self.data.astype(dtype)
-        if self.scale is None:
-            return data
         scale = self.scale.astype(dtype)
         values = data * scale
         return values

--- a/tests/core/test_datatype.py
+++ b/tests/core/test_datatype.py
@@ -35,10 +35,15 @@ class ScaledArrayDataclassTests(chex.TestCase):
         assert isinstance(out, npb.ndarray)
         assert out.dtype == sarr.dtype
         npt.assert_array_equal(out, sarr.data * sarr.scale)
-        # Custom dtype.
+        # Custom float dtype.
         out = sarr.to_array(dtype=np.float32)
         assert isinstance(out, npb.ndarray)
         assert out.dtype == np.float32
+        npt.assert_array_equal(out, sarr.data * sarr.scale)
+        # Custom int dtype.
+        out = sarr.to_array(dtype=np.int8)
+        assert isinstance(out, npb.ndarray)
+        assert out.dtype == np.int8
         npt.assert_array_equal(out, sarr.data * sarr.scale)
 
     @parameterized.parameters(


### PR DESCRIPTION
Implementing `to_array` function to convert a ScaledArray to represented values.

Note: supporting a custom dtype, to avoid potential underflowing/overflowing in case of conversion to more accurate floating point format.