### PR TITLE
register scaled op as decorator

### DIFF
--- a/jax_scaled_arithmetics/core/__init__.py
+++ b/jax_scaled_arithmetics/core/__init__.py
@@ -1,3 +1,3 @@
 # Copyright (c) 2023 Graphcore Ltd. All rights reserved.
 from .datatype import ScaledArray  # noqa: F401
-from .interpreters import autoscale, register_scaled_op  # noqa: F401
+from .interpreters import autoscale, register_scaled_lax_op, register_scaled_op  # noqa: F401

--- a/jax_scaled_arithmetics/core/interpreters.py
+++ b/jax_scaled_arithmetics/core/interpreters.py
@@ -12,18 +12,28 @@ from ..core import ScaledArray
 _scaled_ops_registry = {}
 
 
-def get_lax_prim(scaled_func):
+def register_scaled_op(lax_func, scaled_func):
+    _scaled_ops_registry[lax_func] = scaled_func
+
+
+def _get_lax_prim(scaled_func):
     try:
         op = getattr(jax.lax, scaled_func.__name__.replace("scaled_", ""))
     except AttributeError:
-        print(f"Could not find corresponding jax.lax primitive for {scaled_func.__name__}")
-        raise
+        raise AttributeError(f"Could not find corresponding jax.lax primitive for {scaled_func.__name__}")
     return op
 
 
-def register_scaled_op(scaled_func):
-    lax_prim = get_lax_prim(scaled_func)
-    _scaled_ops_registry[lax_prim] = scaled_func
+def register_scaled_lax_op(scaled_func):
+    """
+    Registers a scaled function into the scaled_ops_registry by matching
+    the function name with pattern `scaled_{func_name}` to a function in the
+    `jax.lax` namespace.
+
+    Example: `scaled_mul_p` is matched to `jax.lax.mul_p`
+    """
+    lax_prim = _get_lax_prim(scaled_func)
+    register_scaled_op(lax_prim, scaled_func)
 
 
 def autoscale(fun):

--- a/jax_scaled_arithmetics/lax/scaled_ops.py
+++ b/jax_scaled_arithmetics/lax/scaled_ops.py
@@ -4,7 +4,7 @@ from jax_scaled_arithmetics import core
 from jax_scaled_arithmetics.core import ScaledArray
 
 
-@core.register_scaled_op
+@core.register_scaled_lax_op
 def scaled_mul_p(A: ScaledArray, B: ScaledArray) -> ScaledArray:
     return ScaledArray(A.data * B.data, A.scale * B.scale)
 


### PR DESCRIPTION
It might get tedious to write the register function every time you add a scaled op.

Here's a suggestion for doing it as a decorator instead.

