### PR TITLE
Fix ScaledArray aval and create factory method.

### DIFF
--- a/jax_scaled_arithmetics/__init__.py
+++ b/jax_scaled_arithmetics/__init__.py
@@ -1,4 +1,4 @@
 # Copyright (c) 2023 Graphcore Ltd. All rights reserved.
 from . import lax
 from ._version import __version__
-from .core import ScaledArray, autoscale  # noqa: F401
+from .core import ScaledArray, autoscale, scaled_array  # noqa: F401

--- a/jax_scaled_arithmetics/core/__init__.py
+++ b/jax_scaled_arithmetics/core/__init__.py
@@ -1,3 +1,3 @@
 # Copyright (c) 2023 Graphcore Ltd. All rights reserved.
-from .datatype import ScaledArray  # noqa: F401
+from .datatype import ScaledArray, scaled_array  # noqa: F401
 from .interpreters import autoscale, register_scaled_lax_op, register_scaled_op  # noqa: F401

--- a/jax_scaled_arithmetics/core/datatype.py
+++ b/jax_scaled_arithmetics/core/datatype.py
@@ -3,10 +3,12 @@ from dataclasses import dataclass
 from typing import Any, Union
 
 import jax
+import jax.numpy as jnp
 import numpy as np
 from chex import Shape
+from jax.core import ShapedArray
 from jax.tree_util import register_pytree_node_class
-from numpy.typing import DTypeLike, NDArray
+from numpy.typing import ArrayLike, DTypeLike, NDArray
 
 GenericArray = Union[jax.Array, np.ndarray]
 
@@ -80,5 +82,22 @@ class ScaledArray:
         return np.asarray(self.to_array(dtype))
 
     @property
-    def aval(self):
-        return self.data * self.scale
+    def aval(self) -> ShapedArray:
+        """Abstract value of the scaled array, i.e. shape and dtype."""
+        return ShapedArray(self.data.shape, self.data.dtype)
+
+
+def scaled_array(data: ArrayLike, scale: ArrayLike, dtype: DTypeLike = None, npapi: Any = jnp) -> ScaledArray:
+    """ScaledArray (helper) factory method, similar to `(j)np.array`.
+
+    Args:
+        data: Main data/values.
+        scale: Scale tensor.
+        dtype: Optional dtype to use for the data.
+        npapi: Numpy API to use.
+    Returns:
+        Scaled array instance.
+    """
+    data = npapi.asarray(data, dtype=dtype)
+    scale = npapi.asarray(scale)
+    return ScaledArray(data, scale)

--- a/tests/core/test_datatype.py
+++ b/tests/core/test_datatype.py
@@ -4,54 +4,73 @@ import jax.numpy as jnp
 import numpy as np
 import numpy.testing as npt
 from absl.testing import parameterized
+from jax.core import ShapedArray
 
-from jax_scaled_arithmetics.core import ScaledArray
+from jax_scaled_arithmetics import ScaledArray, scaled_array
 
 
 class ScaledArrayDataclassTests(chex.TestCase):
     @parameterized.parameters(
-        {"npb": np},
-        {"npb": jnp},
+        {"npapi": np},
+        {"npapi": jnp},
     )
-    def test__scaled_array__init__multi_numpy_backend(self, npb):
-        sarr = ScaledArray(data=npb.array([1.0, 2.0], dtype=np.float32), scale=npb.array(1))
-        assert isinstance(sarr.data, npb.ndarray)
-        assert isinstance(sarr.scale, npb.ndarray)
+    def test__scaled_array__init__multi_numpy_backend(self, npapi):
+        sarr = ScaledArray(data=npapi.array([1.0, 2.0], dtype=np.float32), scale=npapi.array(1))
+        assert isinstance(sarr.data, npapi.ndarray)
+        assert isinstance(sarr.scale, npapi.ndarray)
         assert sarr.scale.shape == ()
 
-    def test__scaled_array__basic_properties(self):
-        sarr = ScaledArray(data=jnp.array([1.0, 2.0]), scale=jnp.array(1))
-        assert sarr.dtype == np.float32
-        assert sarr.shape == (2,)
+    @parameterized.parameters(
+        {"npapi": np},
+        {"npapi": jnp},
+    )
+    def test__scaled_array__factory_method__multi_numpy_backend(self, npapi):
+        sarr = scaled_array(data=[1.0, 2.0], scale=3, dtype=np.float16, npapi=npapi)
+        assert isinstance(sarr, ScaledArray)
+        assert isinstance(sarr.data, npapi.ndarray)
+        assert isinstance(sarr.scale, npapi.ndarray)
+        assert sarr.data.dtype == ShapedArray((2,), np.float16)
+        assert sarr.scale.shape == ()
+        npt.assert_array_almost_equal(sarr, [3, 6])
 
     @parameterized.parameters(
-        {"npb": np},
-        {"npb": jnp},
+        {"npapi": np},
+        {"npapi": jnp},
     )
-    def test__scaled_array__to_array__multi_numpy_backend(self, npb):
-        sarr = ScaledArray(data=npb.array([1.0, 2.0], dtype=np.float16), scale=npb.array(3))
+    def test__scaled_array__basic_properties(self, npapi):
+        sarr = ScaledArray(data=npapi.array([1.0, 2.0], dtype=np.float32), scale=npapi.array(1))
+        assert sarr.dtype == np.float32
+        assert sarr.shape == (2,)
+        assert sarr.aval == ShapedArray((2,), np.float32)
+
+    @parameterized.parameters(
+        {"npapi": np},
+        {"npapi": jnp},
+    )
+    def test__scaled_array__to_array__multi_numpy_backend(self, npapi):
+        sarr = scaled_array(data=[1.0, 2.0], scale=3, dtype=np.float16, npapi=npapi)
         # No dtype specified.
         out = sarr.to_array()
-        assert isinstance(out, npb.ndarray)
+        assert isinstance(out, npapi.ndarray)
         assert out.dtype == sarr.dtype
         npt.assert_array_equal(out, sarr.data * sarr.scale)
         # Custom float dtype.
         out = sarr.to_array(dtype=np.float32)
-        assert isinstance(out, npb.ndarray)
+        assert isinstance(out, npapi.ndarray)
         assert out.dtype == np.float32
         npt.assert_array_equal(out, sarr.data * sarr.scale)
         # Custom int dtype.
         out = sarr.to_array(dtype=np.int8)
-        assert isinstance(out, npb.ndarray)
+        assert isinstance(out, npapi.ndarray)
         assert out.dtype == np.int8
         npt.assert_array_equal(out, sarr.data * sarr.scale)
 
     @parameterized.parameters(
-        {"npb": np},
-        {"npb": jnp},
+        {"npapi": np},
+        {"npapi": jnp},
     )
-    def test__scaled_array__numpy_array_interface(self, npb):
-        sarr = ScaledArray(data=npb.array([1.0, 2.0], dtype=np.float32), scale=npb.array(3))
+    def test__scaled_array__numpy_array_interface(self, npapi):
+        sarr = ScaledArray(data=npapi.array([1.0, 2.0], dtype=np.float32), scale=npapi.array(3))
         out = np.asarray(sarr)
         assert isinstance(out, np.ndarray)
         npt.assert_array_equal(out, sarr.data * sarr.scale)


### PR DESCRIPTION
* `ScaledArray.aval` returning JAX `ShapedArray`, like JAX API;
* Factory method `scaled_array`, similar to `jnp.array`;

The latter makes testing code simpler & clearer.