### PR TITLE
Implement `reduce_sum/prod/max/min` scaled translation rules.

### DIFF
--- a/jax_scaled_arithmetics/core/__init__.py
+++ b/jax_scaled_arithmetics/core/__init__.py
@@ -1,3 +1,9 @@
 # Copyright (c) 2023 Graphcore Ltd. All rights reserved.
 from .datatype import DTypeLike, ScaledArray, Shape, is_scaled_leaf, scaled_array  # noqa: F401
-from .interpreters import ScaledPrimitiveType, autoscale, register_scaled_lax_op, register_scaled_op  # noqa: F401
+from .interpreters import (  # noqa: F401
+    ScaledPrimitiveType,
+    autoscale,
+    find_registered_scaled_op,
+    register_scaled_lax_op,
+    register_scaled_op,
+)


### PR DESCRIPTION
Simple rules, consistent with `add`, `prod`, `min`, `max` primitives.