### PR TITLE
Default scaled translation of JAX primitives.

### DIFF
--- a/jax_scaled_arithmetics/core/__init__.py
+++ b/jax_scaled_arithmetics/core/__init__.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2023 Graphcore Ltd. All rights reserved.
-from .datatype import DTypeLike, ScaledArray, Shape, is_scaled_leaf, scaled_array  # noqa: F401
+from .datatype import DTypeLike, ScaledArray, Shape, asarray, is_scaled_leaf, scaled_array  # noqa: F401
 from .interpreters import (  # noqa: F401
     ScaledPrimitiveType,
     autoscale,

--- a/jax_scaled_arithmetics/core/datatype.py
+++ b/jax_scaled_arithmetics/core/datatype.py
@@ -103,6 +103,22 @@ def scaled_array(data: ArrayLike, scale: ArrayLike, dtype: DTypeLike = None, npa
     return ScaledArray(data, scale)
 
 
+def asarray(val: Any, dtype: DTypeLike = None) -> GenericArray:
+    """Convert back to a common JAX/Numpy array.
+
+    Args:
+        dtype: Optional dtype of the final array.
+    """
+    if isinstance(val, ScaledArray):
+        return val.to_array(dtype=dtype)
+    elif isinstance(val, (jax.Array, np.ndarray)):
+        if dtype is None:
+            return val
+        return val.astype(dtype=dtype)
+    # Convert to Numpy all other cases?
+    return np.asarray(val, dtype=dtype)
+
+
 def is_scaled_leaf(val: Any) -> bool:
     """Is input a JAX PyTree (scaled) leaf, including ScaledArray.
 

--- a/jax_scaled_arithmetics/lax/base_scaling_primitives.py
+++ b/jax_scaled_arithmetics/lax/base_scaling_primitives.py
@@ -6,7 +6,7 @@ from jax import core
 from jax.interpreters import mlir
 from jax.interpreters.mlir import LoweringRuleContext, ir
 
-from jax_scaled_arithmetics.core import DTypeLike, ScaledArray, ScaledPrimitiveType, register_scaled_op
+from jax_scaled_arithmetics.core import DTypeLike, ScaledArray, ScaledPrimitiveType, asarray, register_scaled_op
 
 set_scaling_p = core.Primitive("set_scaling_p")
 """`set_scaling` JAX primitive.
@@ -43,7 +43,7 @@ def scaled_set_scaling(values: ScaledArray, scale: ScaledArray) -> ScaledArray:
     """Scaled `set_scaling` implementation: rebalancing the data using the new scale value."""
     assert scale.shape == ()
     # Automatic promotion should ensure we always get a scaled scalar here!
-    scale_value = scale.to_array()
+    scale_value = asarray(scale)
     if not isinstance(values, ScaledArray):
         # Simple case, with no pre-existing scale.
         return ScaledArray(values / scale_value, scale_value)

--- a/tests/core/test_datatype.py
+++ b/tests/core/test_datatype.py
@@ -6,7 +6,7 @@ import numpy.testing as npt
 from absl.testing import parameterized
 from jax.core import ShapedArray
 
-from jax_scaled_arithmetics.core import ScaledArray, is_scaled_leaf, scaled_array
+from jax_scaled_arithmetics.core import ScaledArray, asarray, is_scaled_leaf, scaled_array
 
 
 class ScaledArrayDataclassTests(chex.TestCase):
@@ -82,3 +82,23 @@ class ScaledArrayDataclassTests(chex.TestCase):
         assert is_scaled_leaf(np.array([3]))
         assert is_scaled_leaf(jnp.array([3]))
         assert is_scaled_leaf(scaled_array(data=[1.0, 2.0], scale=3, dtype=np.float16))
+
+    @parameterized.parameters(
+        {"data": np.array(2)},
+        {"data": np.array([1, 2])},
+        {"data": jnp.array([1, 2])},
+    )
+    def test__asarray__unchanged_dtype(self, data):
+        output = asarray(data)
+        assert output.dtype == data.dtype
+        npt.assert_array_almost_equal(output, data)
+
+    @parameterized.parameters(
+        {"data": np.array([1, 2])},
+        {"data": jnp.array([1, 2])},
+        {"data": scaled_array(data=[1.0, 2.0], scale=3, dtype=np.float32)},
+    )
+    def test__asarray__changed_dtype(self, data):
+        output = asarray(data, dtype=np.float16)
+        assert output.dtype == np.float16
+        npt.assert_array_almost_equal(output, data)


### PR DESCRIPTION
Default scaled translation (i.e. unscale/primitive/rescale) for `log`, `exp` and `select`.
This will unlock minimal operator coverage for MNIST/MLP experiments.