### PR TITLE
Integration tests on high-level SciPy functions.

### DIFF
--- a/jax_scaled_arithmetics/core/__init__.py
+++ b/jax_scaled_arithmetics/core/__init__.py
@@ -7,3 +7,4 @@ from .interpreters import (  # noqa: F401
     register_scaled_lax_op,
     register_scaled_op,
 )
+from .typing import get_numpy_api  # noqa: F401

--- a/jax_scaled_arithmetics/core/typing.py
+++ b/jax_scaled_arithmetics/core/typing.py
@@ -1,1 +1,18 @@
 # Copyright (c) 2023 Graphcore Ltd. All rights reserved.
+from typing import Any
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+
+def get_numpy_api(val: Any) -> Any:
+    """Get the Numpy API corresponding to an array.
+
+    JAX or classic Numpy supported.
+    """
+    if isinstance(val, jax.Array):
+        return jnp
+    elif isinstance(val, (np.ndarray, np.number)):
+        return np
+    raise NotImplementedError(f"Unsupported input type '{type(val)}'. No matching Numpy API.")

--- a/tests/core/test_interpreter.py
+++ b/tests/core/test_interpreter.py
@@ -122,9 +122,12 @@ class AutoScaleInterpreterTests(chex.TestCase):
     @parameterized.parameters(
         {"input": np.array(3)},
         {"input": jnp.array(3)},
+        {"input": 3},
+        {"input": 3.0},
     )
     def test__promote_scalar_to_scaled_array__proper_output(self, input):
         scaled_val = promote_scalar_to_scaled_array(input)
         assert isinstance(scaled_val, ScaledArray)
+        assert scaled_val.data.dtype == scaled_val.scale.dtype
         npt.assert_array_equal(scaled_val.data, 1)
         npt.assert_array_equal(scaled_val.scale, input)

--- a/tests/lax/test_scipy_integration.py
+++ b/tests/lax/test_scipy_integration.py
@@ -1,0 +1,22 @@
+# Copyright (c) 2023 Graphcore Ltd. All rights reserved.
+import chex
+import numpy as np
+import numpy.testing as npt
+
+from jax_scaled_arithmetics.core import autoscale, scaled_array
+
+
+class ScaledTranslationPrimitivesTests(chex.TestCase):
+    def setUp(self):
+        super().setUp()
+        # Use random state for reproducibility!
+        self.rs = np.random.RandomState(42)
+
+    def test__scipy_logsumexp__accurate_scaled_op(self):
+        from jax.scipy.special import logsumexp
+
+        input_scaled = scaled_array(self.rs.rand(10), 2, dtype=np.float32)
+        # JAX `logsumexp` Jaxpr is a non-trivial graph!
+        out_scaled = autoscale(logsumexp)(input_scaled)
+        out_expected = logsumexp(np.asarray(input_scaled))
+        npt.assert_array_almost_equal(out_scaled, out_expected, decimal=5)


### PR DESCRIPTION
SciPy Numpy JAX implementation tend to have additional complexity to deal with corner cases such as `inf`, `nan`, ... We need to make sure that `autoscale` deals properly with these kind of complex graphs.

At moment, only covering `logsumexp` special function.