### PR TITLE
`as_scaled_array` and `asarray` factory methods compatible with JAX PyTrees.

### DIFF
--- a/jax_scaled_arithmetics/core/__init__.py
+++ b/jax_scaled_arithmetics/core/__init__.py
@@ -1,5 +1,13 @@
 # Copyright (c) 2023 Graphcore Ltd. All rights reserved.
-from .datatype import DTypeLike, ScaledArray, Shape, asarray, is_scaled_leaf, scaled_array  # noqa: F401
+from .datatype import (  # noqa: F401
+    DTypeLike,
+    ScaledArray,
+    Shape,
+    as_scaled_array,
+    asarray,
+    is_scaled_leaf,
+    scaled_array,
+)
 from .interpreters import (  # noqa: F401
     ScaledPrimitiveType,
     autoscale,

--- a/tests/core/test_datatype.py
+++ b/tests/core/test_datatype.py
@@ -1,12 +1,13 @@
 # Copyright (c) 2023 Graphcore Ltd. All rights reserved.
 import chex
+import jax
 import jax.numpy as jnp
 import numpy as np
 import numpy.testing as npt
 from absl.testing import parameterized
 from jax.core import ShapedArray
 
-from jax_scaled_arithmetics.core import ScaledArray, asarray, is_scaled_leaf, scaled_array
+from jax_scaled_arithmetics.core import ScaledArray, as_scaled_array, asarray, is_scaled_leaf, scaled_array
 
 
 class ScaledArrayDataclassTests(chex.TestCase):
@@ -78,10 +79,36 @@ class ScaledArrayDataclassTests(chex.TestCase):
     def test__is_scaled_leaf__consistent_with_jax(self):
         assert is_scaled_leaf(8)
         assert is_scaled_leaf(2.0)
+        assert is_scaled_leaf(np.int32(2))
+        assert is_scaled_leaf(np.float32(2))
         assert is_scaled_leaf(np.array(3))
         assert is_scaled_leaf(np.array([3]))
         assert is_scaled_leaf(jnp.array([3]))
         assert is_scaled_leaf(scaled_array(data=[1.0, 2.0], scale=3, dtype=np.float16))
+
+    @parameterized.parameters(
+        {"data": np.array(2)},
+        {"data": np.array([1, 2])},
+        {"data": jnp.array([1, 2])},
+    )
+    def test__as_scaled_array__unchanged_dtype(self, data):
+        output = as_scaled_array(data)
+        assert isinstance(output, ScaledArray)
+        assert isinstance(output.data, type(data))
+        assert output.dtype == data.dtype
+        npt.assert_array_almost_equal(output, data)
+        npt.assert_array_equal(output.scale, np.array(1, dtype=data.dtype))
+        # unvariant when calling a second time.
+        assert as_scaled_array(output) is output
+
+    def test__as_scaled_array__complex_pytree(self):
+        input = {"x": jnp.array([1, 2]), "y": as_scaled_array(jnp.array([1, 2]))}
+        output = as_scaled_array(input)
+        assert isinstance(output, dict)
+        assert len(output) == 2
+        assert isinstance(output["x"], ScaledArray)
+        npt.assert_array_equal(output["x"], input["x"])
+        assert output["y"] is input["y"]
 
     @parameterized.parameters(
         {"data": np.array(2)},
@@ -102,3 +129,12 @@ class ScaledArrayDataclassTests(chex.TestCase):
         output = asarray(data, dtype=np.float16)
         assert output.dtype == np.float16
         npt.assert_array_almost_equal(output, data)
+
+    def test__asarray__complex_pytree(self):
+        input = {"x": jnp.array([1.0, 2]), "y": scaled_array(jnp.array([3, 4.0]), jnp.array(0.5))}
+        output = asarray(input)
+        assert isinstance(output, dict)
+        assert len(output) == 2
+        assert all([isinstance(v, jax.Array) for v in output.values()])
+        npt.assert_array_almost_equal(output["x"], input["x"])
+        npt.assert_array_almost_equal(output["y"], input["y"])


### PR DESCRIPTION
Similarly to `jax.device_put/get`, allowing easy handling of complex datastructures
like model state or batch.