### PR TITLE
Add JAX 0.3.x compatibility. Useful for running experiments on IPUs.

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -48,7 +48,14 @@ jobs:
         run: |
           pip3 install -e ./
           pip3 install -r ./test-requirements.txt
-      # Run repository unit tests.
-      - name: Run unit tests
+      # Run repository unit tests on latest JAX
+      - name: Run unit tests JAX latest
+        run: |
+          pytest --tb=short -v --log-cli-level=INFO ./
+      - name: JAX 0.3.16 installation
+        run: |
+          pip3 install chex==0.1.6 jax==0.3.16 jaxlib==0.3.15 -f https://storage.googleapis.com/jax-releases/jax_releases.html
+      # Run repository unit tests on JAX 0.3
+      - name: Run unit tests JAX 0.3.16
         run: |
           pytest --tb=short -v --log-cli-level=INFO ./

--- a/jax_scaled_arithmetics/core/__init__.py
+++ b/jax_scaled_arithmetics/core/__init__.py
@@ -15,4 +15,4 @@ from .interpreters import (  # noqa: F401
     register_scaled_lax_op,
     register_scaled_op,
 )
-from .typing import get_numpy_api  # noqa: F401
+from .typing import Array, ArrayTypes, get_numpy_api  # noqa: F401

--- a/jax_scaled_arithmetics/core/typing.py
+++ b/jax_scaled_arithmetics/core/typing.py
@@ -1,9 +1,19 @@
 # Copyright (c) 2023 Graphcore Ltd. All rights reserved.
 from typing import Any
 
+# import chex
 import jax
 import jax.numpy as jnp
+import jaxlib
 import numpy as np
+
+# Type aliasing. To be compatible with JAX 0.3 as well.
+if jax.__version_info__[1] > 3:
+    Array = jax.Array
+    ArrayTypes = (jax.Array,)
+else:
+    Array = jaxlib.xla_extension.DeviceArray
+    ArrayTypes = (jaxlib.xla_extension.DeviceArray, jax.interpreters.partial_eval.DynamicJaxprTracer)  # type:ignore
 
 
 def get_numpy_api(val: Any) -> Any:

--- a/jax_scaled_arithmetics/lax/base_scaling_primitives.py
+++ b/jax_scaled_arithmetics/lax/base_scaling_primitives.py
@@ -1,12 +1,11 @@
 # Copyright (c) 2023 Graphcore Ltd. All rights reserved.
 from typing import Optional, Sequence, Union
 
-import jax
 from jax import core
 from jax.interpreters import mlir
 from jax.interpreters.mlir import LoweringRuleContext, ir
 
-from jax_scaled_arithmetics.core import DTypeLike, ScaledArray, ScaledPrimitiveType, asarray, register_scaled_op
+from jax_scaled_arithmetics.core import Array, DTypeLike, ScaledArray, ScaledPrimitiveType, asarray, register_scaled_op
 
 set_scaling_p = core.Primitive("set_scaling_p")
 """`set_scaling` JAX primitive.
@@ -19,12 +18,12 @@ return a ScaledArray semantically equivalent.
 """
 
 
-def set_scaling(values: jax.Array, scale: jax.Array) -> jax.Array:
+def set_scaling(values: Array, scale: Array) -> Array:
     """`set_scaling` primitive call method."""
     return set_scaling_p.bind(values, scale)
 
 
-def set_scaling_impl(values: jax.Array, scale: jax.Array) -> jax.Array:
+def set_scaling_impl(values: Array, scale: Array) -> Array:
     return values
 
 
@@ -73,12 +72,12 @@ Similar in principle to `jax.lax.stop_gradient`
 """
 
 
-def stop_scaling(values: jax.Array, dtype: Optional[DTypeLike] = None) -> jax.Array:
+def stop_scaling(values: Array, dtype: Optional[DTypeLike] = None) -> Array:
     """`stop_scaling` primitive call method."""
     return stop_scaling_p.bind(values, dtype=dtype)
 
 
-def stop_scaling_impl(values: jax.Array, dtype: Optional[DTypeLike]) -> jax.Array:
+def stop_scaling_impl(values: Array, dtype: Optional[DTypeLike]) -> Array:
     if dtype is not None:
         values = values.astype(dtype)
     return values
@@ -100,7 +99,7 @@ def stop_scaling_mlir_lowering(
     return (args[0],)
 
 
-def scaled_stop_scaling(values: ScaledArray, dtype: Optional[DTypeLike] = None) -> jax.Array:
+def scaled_stop_scaling(values: ScaledArray, dtype: Optional[DTypeLike] = None) -> Array:
     """Scaled `stop_scaling` implementation: returning tensor values (with optional cast)."""
     assert isinstance(values, ScaledArray)
     # TODO/FIXME: how to handle not scaled input?

--- a/jax_scaled_arithmetics/lax/scaled_ops.py
+++ b/jax_scaled_arithmetics/lax/scaled_ops.py
@@ -9,7 +9,7 @@ from jax import lax
 from jax._src.ad_util import add_any_p
 
 from jax_scaled_arithmetics import core
-from jax_scaled_arithmetics.core import DTypeLike, ScaledArray, Shape, as_scaled_array, register_scaled_op
+from jax_scaled_arithmetics.core import Array, DTypeLike, ScaledArray, Shape, as_scaled_array, register_scaled_op
 
 from .base_scaling_primitives import scaled_set_scaling
 
@@ -204,7 +204,7 @@ def scaled_reduce_min(val: ScaledArray, axes: Tuple[int]) -> ScaledArray:
 
 
 @core.register_scaled_lax_op
-def scaled_is_finite(val: ScaledArray) -> jax.Array:
+def scaled_is_finite(val: ScaledArray) -> Array:
     assert isinstance(val, ScaledArray)
     if np.issubdtype(val.scale.dtype, np.integer):
         # Integer scale case => only check the data component.
@@ -213,7 +213,7 @@ def scaled_is_finite(val: ScaledArray) -> jax.Array:
     return lax.and_p.bind(lax.is_finite(val.data), lax.is_finite(val.scale))
 
 
-def scaled_boolean_binary_op(lhs: ScaledArray, rhs: ScaledArray, prim: jax.core.Primitive) -> jax.Array:
+def scaled_boolean_binary_op(lhs: ScaledArray, rhs: ScaledArray, prim: jax.core.Primitive) -> Array:
     """Generic implementation of any boolean binary operation."""
     assert isinstance(lhs, ScaledArray)
     assert isinstance(rhs, ScaledArray)
@@ -223,32 +223,32 @@ def scaled_boolean_binary_op(lhs: ScaledArray, rhs: ScaledArray, prim: jax.core.
 
 
 @core.register_scaled_lax_op
-def scaled_eq(lhs: ScaledArray, rhs: ScaledArray) -> jax.Array:
+def scaled_eq(lhs: ScaledArray, rhs: ScaledArray) -> Array:
     return scaled_boolean_binary_op(lhs, rhs, lax.eq_p)
 
 
 @core.register_scaled_lax_op
-def scaled_ne(lhs: ScaledArray, rhs: ScaledArray) -> jax.Array:
+def scaled_ne(lhs: ScaledArray, rhs: ScaledArray) -> Array:
     return scaled_boolean_binary_op(lhs, rhs, lax.ne_p)
 
 
 @core.register_scaled_lax_op
-def scaled_gt(lhs: ScaledArray, rhs: ScaledArray) -> jax.Array:
+def scaled_gt(lhs: ScaledArray, rhs: ScaledArray) -> Array:
     return scaled_boolean_binary_op(lhs, rhs, lax.gt_p)
 
 
 @core.register_scaled_lax_op
-def scaled_ge(lhs: ScaledArray, rhs: ScaledArray) -> jax.Array:
+def scaled_ge(lhs: ScaledArray, rhs: ScaledArray) -> Array:
     return scaled_boolean_binary_op(lhs, rhs, lax.ge_p)
 
 
 @core.register_scaled_lax_op
-def scaled_lt(lhs: ScaledArray, rhs: ScaledArray) -> jax.Array:
+def scaled_lt(lhs: ScaledArray, rhs: ScaledArray) -> Array:
     return scaled_boolean_binary_op(lhs, rhs, lax.lt_p)
 
 
 @core.register_scaled_lax_op
-def scaled_le(lhs: ScaledArray, rhs: ScaledArray) -> jax.Array:
+def scaled_le(lhs: ScaledArray, rhs: ScaledArray) -> Array:
     return scaled_boolean_binary_op(lhs, rhs, lax.le_p)
 
 
@@ -256,7 +256,7 @@ def scaled_le(lhs: ScaledArray, rhs: ScaledArray) -> jax.Array:
 # Default scaled ops implementation #
 ##################################################################
 def scaled_op_default_translation(
-    prim: jax.core.Primitive, args: Sequence[ScaledArray], outscale: Optional[jax.Array] = None
+    prim: jax.core.Primitive, args: Sequence[ScaledArray], outscale: Optional[Array] = None
 ) -> ScaledArray:
     """Scaled op default translation of a JAX primitive: unscaling inputs + calling normal primitive.
 
@@ -285,7 +285,7 @@ def scaled_log(val: ScaledArray) -> ScaledArray:
 
 
 @core.register_scaled_lax_op
-def scaled_select_n(which: jax.Array, *cases: ScaledArray) -> ScaledArray:
+def scaled_select_n(which: Array, *cases: ScaledArray) -> ScaledArray:
     return scaled_op_default_translation(lax.select_n_p, [which, *cases])
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
 ]
 dependencies = [
-  "chex",
+  "chex >= 0.1.6",
   "jax >= 0.3.16",
   "jaxlib >= 0.3.15",
   "numpy >= 1.22.4"

--- a/tests/core/test_datatype.py
+++ b/tests/core/test_datatype.py
@@ -1,13 +1,12 @@
 # Copyright (c) 2023 Graphcore Ltd. All rights reserved.
 import chex
-import jax
 import jax.numpy as jnp
 import numpy as np
 import numpy.testing as npt
 from absl.testing import parameterized
 from jax.core import ShapedArray
 
-from jax_scaled_arithmetics.core import ScaledArray, as_scaled_array, asarray, is_scaled_leaf, scaled_array
+from jax_scaled_arithmetics.core import Array, ScaledArray, as_scaled_array, asarray, is_scaled_leaf, scaled_array
 
 
 class ScaledArrayDataclassTests(chex.TestCase):
@@ -135,6 +134,6 @@ class ScaledArrayDataclassTests(chex.TestCase):
         output = asarray(input)
         assert isinstance(output, dict)
         assert len(output) == 2
-        assert all([isinstance(v, jax.Array) for v in output.values()])
+        assert all([isinstance(v, Array) for v in output.values()])
         npt.assert_array_almost_equal(output["x"], input["x"])
         npt.assert_array_almost_equal(output["y"], input["y"])

--- a/tests/lax/test_base_scaling_primitives.py
+++ b/tests/lax/test_base_scaling_primitives.py
@@ -1,12 +1,11 @@
 # Copyright (c) 2023 Graphcore Ltd. All rights reserved.
 import chex
-import jax
 import jax.numpy as jnp
 import numpy as np
 import numpy.testing as npt
 from absl.testing import parameterized
 
-from jax_scaled_arithmetics.core import ScaledArray, autoscale, scaled_array
+from jax_scaled_arithmetics.core import Array, ScaledArray, autoscale, scaled_array
 from jax_scaled_arithmetics.lax import set_scaling, stop_scaling
 
 
@@ -64,8 +63,8 @@ class StopScalingPrimitiveTests(chex.TestCase):
         fn = self.variant(autoscale(fn))
         arr = scaled_array([-1.0, 2.0], 3.0, dtype=np.float32)
         out0, out1 = fn(arr)
-        assert isinstance(out0, jax.Array)
-        assert isinstance(out1, jax.Array)
+        assert isinstance(out0, Array)
+        assert isinstance(out1, Array)
         assert out0.dtype == arr.dtype
         assert out1.dtype == np.float16
         npt.assert_array_equal(out0, arr)

--- a/tests/lax/test_scaled_ops.py
+++ b/tests/lax/test_scaled_ops.py
@@ -1,12 +1,11 @@
 # Copyright (c) 2023 Graphcore Ltd. All rights reserved.
 import chex
-import jax
 import numpy as np
 import numpy.testing as npt
 from absl.testing import parameterized
 from jax import lax
 
-from jax_scaled_arithmetics.core import ScaledArray, find_registered_scaled_op, scaled_array
+from jax_scaled_arithmetics.core import Array, ScaledArray, find_registered_scaled_op, scaled_array
 from jax_scaled_arithmetics.lax import (
     scaled_add,
     scaled_broadcast_in_dim,
@@ -199,7 +198,7 @@ class ScaledTranslationBooleanPrimitivesTests(chex.TestCase):
     )
     def test__scaled_is_finite__proper_result(self, val, expected_out):
         out = scaled_is_finite(val)
-        assert isinstance(out, jax.Array)
+        assert isinstance(out, Array)
         assert out.dtype == np.bool_
         npt.assert_array_equal(out, expected_out)
 
@@ -217,7 +216,7 @@ class ScaledTranslationBooleanPrimitivesTests(chex.TestCase):
         scaled_bool_op, _ = find_registered_scaled_op(bool_prim)
         out0 = scaled_bool_op(lhs, rhs)
         out1 = scaled_bool_op(lhs, lhs)
-        assert isinstance(out0, jax.Array)
+        assert isinstance(out0, Array)
         assert out0.dtype == np.bool_
         npt.assert_array_equal(out0, bool_prim.bind(lhs.to_array(), rhs.to_array()))
         npt.assert_array_equal(out1, bool_prim.bind(lhs.to_array(), lhs.to_array()))


### PR DESCRIPTION
Main changes:
* `jax.Array` typing, using `DeviceArray` in JAX 0.3;
* `xla_call_p`: specific support for JAX 0.3;
* `custom_jvp`: adapting for both JAX versions;