### PR TITLE
Fix FP16/FP32 promotion rules in JAX LAX scaled binary operations.

### DIFF
--- a/tests/lax/test_scaled_ops.py
+++ b/tests/lax/test_scaled_ops.py
@@ -8,7 +8,6 @@ from jax import lax
 from jax_scaled_arithmetics.core import Array, ScaledArray, find_registered_scaled_op, scaled_array
 from jax_scaled_arithmetics.lax import (
     scaled_abs,
-    scaled_add,
     scaled_broadcast_in_dim,
     scaled_concatenate,
     scaled_convert_element_type,
@@ -28,7 +27,6 @@ from jax_scaled_arithmetics.lax import (
     scaled_rev,
     scaled_select_n,
     scaled_slice,
-    scaled_sub,
     scaled_transpose,
 )
 
@@ -134,24 +132,6 @@ class ScaledTranslationPrimitivesTests(chex.TestCase):
         assert z.scale == 1.5
         npt.assert_array_almost_equal(z, np.asarray(x) / np.asarray(y))
 
-    def test__scaled_add__proper_scaling(self):
-        x = scaled_array([-1.0, 2.0], 3.0, dtype=np.float32)
-        y = scaled_array([1.5, 4.5], 2.0, dtype=np.float32)
-        z = scaled_add(x, y)
-        assert isinstance(z, ScaledArray)
-        assert z.dtype == x.dtype
-        npt.assert_almost_equal(z.scale, np.sqrt(4.0 + 9.0))
-        npt.assert_array_almost_equal(z, np.asarray(x) + np.asarray(y))
-
-    def test__scaled_sub__proper_scaling(self):
-        x = scaled_array([-1.0, 2.0], 3.0, dtype=np.float32)
-        y = scaled_array([1.5, 4.5], 2.0, dtype=np.float32)
-        z = scaled_sub(x, y)
-        assert isinstance(z, ScaledArray)
-        assert z.dtype == x.dtype
-        npt.assert_almost_equal(z.scale, np.sqrt(4.0 + 9.0))
-        npt.assert_array_almost_equal(z, np.asarray(x) - np.asarray(y))
-
     def test__scaled_dot_general__proper_scaling(self):
         lhs = scaled_array(self.rs.rand(3, 5), 2.0, dtype=np.float32)
         rhs = scaled_array(self.rs.rand(5, 2), 3.0, dtype=np.float32)
@@ -199,6 +179,52 @@ class ScaledTranslationPrimitivesTests(chex.TestCase):
         out = scaled_translation(x, axes=(0,), index_dtype=np.int32)
         assert isinstance(out, Array)
         npt.assert_array_equal(out, expected_out)
+
+
+class ScaledTranslationBinaryOpsTests(chex.TestCase):
+    def setUp(self):
+        super().setUp()
+        # Use random state for reproducibility!
+        self.rs = np.random.RandomState(42)
+
+    @parameterized.parameters(
+        {"prim": lax.add_p, "dtype": np.float32},
+        {"prim": lax.sub_p, "dtype": np.float32},
+        {"prim": lax.mul_p, "dtype": np.float32},
+        {"prim": lax.div_p, "dtype": np.float32},
+        # Make sure type promotion is right!
+        {"prim": lax.add_p, "dtype": np.float16},
+        {"prim": lax.sub_p, "dtype": np.float16},
+        {"prim": lax.mul_p, "dtype": np.float16},
+        {"prim": lax.div_p, "dtype": np.float16},
+    )
+    def test__scaled_binary_op__proper_result_and_promotion(self, prim, dtype):
+        scaled_op, _ = find_registered_scaled_op(prim)
+        x = scaled_array([-1.0, 2.0], 3.0, dtype=dtype)
+        y = scaled_array([1.5, 4.5], 2.0, dtype=dtype)
+        # Always use float32 for scale factor.
+        assert x.scale.dtype == np.float32
+        assert y.scale.dtype == np.float32
+
+        z = scaled_op(x, y)
+        expected_z = prim.bind(np.asarray(x), np.asarray(y))
+
+        assert z.dtype == x.dtype
+        assert z.scale.dtype == x.scale.dtype
+        npt.assert_array_almost_equal(z, expected_z, decimal=5)
+
+    @parameterized.parameters(
+        {"prim": lax.add_p},
+        {"prim": lax.sub_p},
+    )
+    def test__scaled_addsub__proper_scaling(self, prim):
+        scaled_op, _ = find_registered_scaled_op(prim)
+        x = scaled_array([-1.0, 2.0], 3.0, dtype=np.float32)
+        y = scaled_array([1.5, 4.5], 2.0, dtype=np.float32)
+        z = scaled_op(x, y)
+        assert isinstance(z, ScaledArray)
+        assert z.dtype == x.dtype
+        npt.assert_almost_equal(z.scale, np.sqrt(4.0 + 9.0))
 
 
 class ScaledTranslationReducePrimitivesTests(chex.TestCase):


### PR DESCRIPTION
One needs to be careful with dtype promotion in scaled ops translation rules, as the scaling factor can potentially be in higher precision than the bulk of the data.