### PR TITLE
Expand test coverage for FP16 type promotion

### DIFF
--- a/jax_scaled_arithmetics/core/__init__.py
+++ b/jax_scaled_arithmetics/core/__init__.py
@@ -6,6 +6,7 @@ from .datatype import (  # noqa: F401
     as_scaled_array,
     asarray,
     is_scaled_leaf,
+    is_static_one_scalar,
     is_static_zero,
     scaled_array,
 )

--- a/jax_scaled_arithmetics/core/datatype.py
+++ b/jax_scaled_arithmetics/core/datatype.py
@@ -67,6 +67,10 @@ class ScaledArray:
     def shape(self) -> Shape:
         return self.data.shape
 
+    @property
+    def size(self) -> int:
+        return self.data.size
+
     def to_array(self, dtype: DTypeLike = None) -> GenericArray:
         """Convert to the scaled array to a Numpy/JAX array.
 
@@ -208,3 +212,14 @@ def is_static_zero(val: Union[Array, ScaledArray]) -> Array:
         return np.logical_or(data_mask, scale_mask)
     # By default: can't decide.
     return np.zeros(val.shape, dtype=np.bool_)
+
+
+def is_static_one_scalar(val: Array) -> Union[bool, np.bool_]:
+    """Is a scaled array a static one scalar value (i.e. one during JAX tracing as well)?"""
+    if isinstance(val, (int, float)):
+        return val == 1
+    elif is_numpy_scalar_or_array(val) and val.size == 1:
+        return np.all(np.equal(val, 1))
+    elif isinstance(val, ScaledArray) and val.size == 1:
+        return is_static_one_scalar(val.data) and is_static_one_scalar(val.scale)
+    return False

--- a/tests/lax/test_scipy_integration.py
+++ b/tests/lax/test_scipy_integration.py
@@ -2,6 +2,7 @@
 import chex
 import numpy as np
 import numpy.testing as npt
+from absl.testing import parameterized
 
 from jax_scaled_arithmetics.core import autoscale, scaled_array
 
@@ -12,11 +13,16 @@ class ScaledTranslationPrimitivesTests(chex.TestCase):
         # Use random state for reproducibility!
         self.rs = np.random.RandomState(42)
 
-    def test__scipy_logsumexp__accurate_scaled_op(self):
+    @parameterized.parameters(
+        {"dtype": np.float32},
+        {"dtype": np.float16},
+    )
+    def test__scipy_logsumexp__accurate_scaled_op(self, dtype):
         from jax.scipy.special import logsumexp
 
-        input_scaled = scaled_array(self.rs.rand(10), 2, dtype=np.float32)
+        input_scaled = scaled_array(self.rs.rand(10), 2, dtype=dtype)
         # JAX `logsumexp` Jaxpr is a non-trivial graph!
         out_scaled = autoscale(logsumexp)(input_scaled)
         out_expected = logsumexp(np.asarray(input_scaled))
+        assert out_scaled.dtype == out_expected.dtype
         npt.assert_array_almost_equal(out_scaled, out_expected, decimal=5)


### PR DESCRIPTION
Additional operations with type promotion checks:
* Unary ops (exp, log, neg, abs);
* Binary min/max ops;
* Dot product;