### PR TITLE
Re-organize scaled ops translations into common and L2 rules.

### DIFF
--- a/jax_scaled_arithmetics/lax/__init__.py
+++ b/jax_scaled_arithmetics/lax/__init__.py
@@ -1,3 +1,4 @@
 # Copyright (c) 2023 Graphcore Ltd. All rights reserved.
 from .base_scaling_primitives import set_scaling, set_scaling_p, stop_scaling, stop_scaling_p  # noqa: F401
-from .scaled_ops import *  # noqa: F401, F403
+from .scaled_ops_common import *  # noqa: F401, F403
+from .scaled_ops_l2 import *  # noqa: F401, F403

--- a/jax_scaled_arithmetics/lax/scaled_ops_common.py
+++ b/jax_scaled_arithmetics/lax/scaled_ops_common.py
@@ -1,23 +1,14 @@
 # Copyright (c) 2023 Graphcore Ltd. All rights reserved.
-from typing import Any, Optional, Sequence, Tuple
+from typing import Any, Optional, Sequence
 
 import jax
 import jax.core
 import jax.numpy as jnp
 import numpy as np
 from jax import lax
-from jax._src.ad_util import add_any_p
 
 from jax_scaled_arithmetics import core
-from jax_scaled_arithmetics.core import (
-    Array,
-    DTypeLike,
-    ScaledArray,
-    Shape,
-    as_scaled_array,
-    is_static_zero,
-    register_scaled_op,
-)
+from jax_scaled_arithmetics.core import Array, DTypeLike, ScaledArray, Shape, as_scaled_array, is_static_zero
 
 from .base_scaling_primitives import scaled_set_scaling
 
@@ -156,191 +147,6 @@ def scaled_div(lhs: ScaledArray, rhs: ScaledArray) -> ScaledArray:
     lhs, rhs = as_scaled_array((lhs, rhs))  # type:ignore
     # TODO: investigate different rule?
     return ScaledArray(lhs.data / rhs.data, lhs.scale / rhs.scale)
-
-
-@core.register_scaled_lax_op
-def scaled_add(A: ScaledArray, B: ScaledArray) -> ScaledArray:
-    # TODO: understand when promotion is really required?
-    A, B = as_scaled_array((A, B))  # type:ignore
-    check_scalar_scales(A, B)
-    A, B = promote_scale_types(A, B)
-    assert np.issubdtype(A.scale.dtype, np.floating)
-    # TODO: what happens to `sqrt` for non-floating scale?
-    output_scale = lax.sqrt(A.scale * A.scale + B.scale * B.scale)
-    # Output dtype => promotion of A and B dtypes.
-    outdtype = jnp.promote_types(A.dtype, B.dtype)
-    Arescale = (A.scale / output_scale).astype(outdtype)
-    Brescale = (B.scale / output_scale).astype(outdtype)
-    # check correct type output if mismatch between data and scale precision
-    output_data = Arescale * A.data + Brescale * B.data
-    return ScaledArray(output_data, output_scale)
-
-
-# TODO: understand difference between `add` and `add_anys`
-register_scaled_op(add_any_p, scaled_add)
-
-
-@core.register_scaled_lax_op
-def scaled_sub(A: ScaledArray, B: ScaledArray) -> ScaledArray:
-    # TODO: understand when promotion is really required?
-    A, B = as_scaled_array((A, B))  # type:ignore
-    check_scalar_scales(A, B)
-    A, B = promote_scale_types(A, B)
-    assert np.issubdtype(A.scale.dtype, np.floating)
-    # TODO: what happens to `sqrt` for non-floating scale?
-    output_scale = lax.sqrt(A.scale * A.scale + B.scale * B.scale)
-    # Output dtype => promotion of A and B dtypes.
-    outdtype = jnp.promote_types(A.dtype, B.dtype)
-    Arescale = (A.scale / output_scale).astype(outdtype)
-    Brescale = (B.scale / output_scale).astype(outdtype)
-    # check correct type output if mismatch between data and scale precision
-    output_data = Arescale * A.data - Brescale * B.data
-    return ScaledArray(output_data, output_scale)
-
-
-@core.register_scaled_lax_op
-def scaled_dot_general(
-    lhs: ScaledArray,
-    rhs: ScaledArray,
-    dimension_numbers: Tuple[Tuple[Sequence[int], Sequence[int]], Tuple[Sequence[int], Sequence[int]]],
-    precision: Any = None,
-    preferred_element_type: Optional[DTypeLike] = None,
-) -> ScaledArray:
-    # Checks on `dot_general` arguments. Only supporting a subset right now.
-    ((lhs_contracting_dims, rhs_contracting_dims), (lhs_batch_dims, rhs_batch_dims)) = dimension_numbers
-    assert len(lhs_batch_dims) == 0
-    assert len(rhs_batch_dims) == 0
-    assert len(lhs_contracting_dims) == 1
-    assert len(rhs_contracting_dims) == 1
-
-    contracting_dim_size = lhs.shape[lhs_contracting_dims[0]]
-    # "unit scaling" rule, based on the contracting axis.
-    outscale_dtype = jnp.promote_types(lhs.scale.dtype, rhs.scale.dtype)
-    contracting_rescale = np.sqrt(contracting_dim_size)
-    output_scale = lhs.scale * rhs.scale * contracting_rescale.astype(outscale_dtype)
-    # NOTE: need to be a bit careful about scale promotion?
-    output_data = lax.dot_general(
-        lhs.data,
-        rhs.data,
-        dimension_numbers=dimension_numbers,
-        precision=precision,
-        preferred_element_type=preferred_element_type,
-    )
-    output_data = output_data / contracting_rescale.astype(output_data.dtype)
-    return ScaledArray(output_data, output_scale)
-
-
-@core.register_scaled_lax_op
-def scaled_conv_general_dilated(lhs: ScaledArray, rhs: ScaledArray, **params) -> ScaledArray:
-    assert isinstance(lhs, ScaledArray)
-    assert isinstance(rhs, ScaledArray)
-    data = lax.conv_general_dilated_p.bind(lhs.data, rhs.data, **params)
-    # FIXME: should we change scaling if e.g. window > 3?
-    return ScaledArray(data, lhs.scale * rhs.scale)
-
-
-@core.register_scaled_lax_op
-def scaled_reduce_sum(val: ScaledArray, axes: Tuple[int]) -> ScaledArray:
-    assert isinstance(val, ScaledArray)
-    shape = val.shape
-    axes_size = np.array([shape[idx] for idx in axes])
-    # Rescale data component following reduction axes.
-    axes_rescale = np.sqrt(np.prod(axes_size))
-    data = lax.reduce_sum_p.bind(val.data, axes=axes) / axes_rescale.astype(val.data.dtype)
-    outscale = val.scale * axes_rescale.astype(val.scale.dtype)
-    return ScaledArray(data, outscale)
-
-
-@core.register_scaled_lax_op
-def scaled_reduce_prod(val: ScaledArray, axes: Tuple[int]) -> ScaledArray:
-    assert isinstance(val, ScaledArray)
-    shape = val.shape
-    data = lax.reduce_prod_p.bind(val.data, axes=axes)
-    axes_size = np.prod(np.array([shape[idx] for idx in axes]))
-    scale = lax.integer_pow(val.scale, axes_size)
-    return ScaledArray(data, scale)
-
-
-@core.register_scaled_lax_op
-def scaled_reduce_max(val: ScaledArray, axes: Tuple[int]) -> ScaledArray:
-    assert isinstance(val, ScaledArray)
-    data = lax.reduce_max_p.bind(val.data, axes=axes)
-    # unchanged scaling.
-    return ScaledArray(data, val.scale)
-
-
-@core.register_scaled_lax_op
-def scaled_reduce_min(val: ScaledArray, axes: Tuple[int]) -> ScaledArray:
-    assert isinstance(val, ScaledArray)
-    data = lax.reduce_min_p.bind(val.data, axes=axes)
-    # unchanged scaling.
-    return ScaledArray(data, val.scale)
-
-
-@core.register_scaled_lax_op
-def scaled_reduce_window_sum(
-    val: ScaledArray,
-    window_dimensions: Any,
-    window_strides: Any,
-    padding: Any,
-    base_dilation: Any,
-    window_dilation: Any,
-) -> ScaledArray:
-    assert isinstance(val, ScaledArray)
-    data = lax.reduce_window_sum_p.bind(
-        val.data,
-        window_dimensions=window_dimensions,
-        window_strides=window_strides,
-        padding=padding,
-        base_dilation=base_dilation,
-        window_dilation=window_dilation,
-    )
-    # FIXME: should we change scaling if e.g. window > 3?
-    return ScaledArray(data, val.scale)
-
-
-@core.register_scaled_lax_op
-def scaled_reduce_window_min(
-    val: ScaledArray,
-    window_dimensions: Any,
-    window_strides: Any,
-    padding: Any,
-    base_dilation: Any,
-    window_dilation: Any,
-) -> ScaledArray:
-    assert isinstance(val, ScaledArray)
-    data = lax.reduce_window_min_p.bind(
-        val.data,
-        window_dimensions=window_dimensions,
-        window_strides=window_strides,
-        padding=padding,
-        base_dilation=base_dilation,
-        window_dilation=window_dilation,
-    )
-    # unchanged scaling.
-    return ScaledArray(data, val.scale)
-
-
-@core.register_scaled_lax_op
-def scaled_reduce_window_max(
-    val: ScaledArray,
-    window_dimensions: Any,
-    window_strides: Any,
-    padding: Any,
-    base_dilation: Any,
-    window_dilation: Any,
-) -> ScaledArray:
-    assert isinstance(val, ScaledArray)
-    data = lax.reduce_window_max_p.bind(
-        val.data,
-        window_dimensions=window_dimensions,
-        window_strides=window_strides,
-        padding=padding,
-        base_dilation=base_dilation,
-        window_dilation=window_dilation,
-    )
-    # unchanged scaling.
-    return ScaledArray(data, val.scale)
 
 
 @core.register_scaled_lax_op

--- a/jax_scaled_arithmetics/lax/scaled_ops_l2.py
+++ b/jax_scaled_arithmetics/lax/scaled_ops_l2.py
@@ -1,0 +1,197 @@
+# Copyright (c) 2023 Graphcore Ltd. All rights reserved.
+from typing import Any, Optional, Sequence, Tuple
+
+import jax.numpy as jnp
+import numpy as np
+from jax import lax
+from jax._src.ad_util import add_any_p
+
+from jax_scaled_arithmetics import core
+from jax_scaled_arithmetics.core import DTypeLike, ScaledArray, as_scaled_array, register_scaled_op
+
+from .scaled_ops_common import check_scalar_scales, promote_scale_types
+
+
+@core.register_scaled_lax_op
+def scaled_add(A: ScaledArray, B: ScaledArray) -> ScaledArray:
+    # TODO: understand when promotion is really required?
+    A, B = as_scaled_array((A, B))  # type:ignore
+    check_scalar_scales(A, B)
+    A, B = promote_scale_types(A, B)
+    assert np.issubdtype(A.scale.dtype, np.floating)
+    # TODO: what happens to `sqrt` for non-floating scale?
+    output_scale = lax.sqrt(A.scale * A.scale + B.scale * B.scale)
+    # Output dtype => promotion of A and B dtypes.
+    outdtype = jnp.promote_types(A.dtype, B.dtype)
+    Arescale = (A.scale / output_scale).astype(outdtype)
+    Brescale = (B.scale / output_scale).astype(outdtype)
+    # check correct type output if mismatch between data and scale precision
+    output_data = Arescale * A.data + Brescale * B.data
+    return ScaledArray(output_data, output_scale)
+
+
+# TODO: understand difference between `add` and `add_anys`
+register_scaled_op(add_any_p, scaled_add)
+
+
+@core.register_scaled_lax_op
+def scaled_sub(A: ScaledArray, B: ScaledArray) -> ScaledArray:
+    # TODO: understand when promotion is really required?
+    A, B = as_scaled_array((A, B))  # type:ignore
+    check_scalar_scales(A, B)
+    A, B = promote_scale_types(A, B)
+    assert np.issubdtype(A.scale.dtype, np.floating)
+    # TODO: what happens to `sqrt` for non-floating scale?
+    output_scale = lax.sqrt(A.scale * A.scale + B.scale * B.scale)
+    # Output dtype => promotion of A and B dtypes.
+    outdtype = jnp.promote_types(A.dtype, B.dtype)
+    Arescale = (A.scale / output_scale).astype(outdtype)
+    Brescale = (B.scale / output_scale).astype(outdtype)
+    # check correct type output if mismatch between data and scale precision
+    output_data = Arescale * A.data - Brescale * B.data
+    return ScaledArray(output_data, output_scale)
+
+
+@core.register_scaled_lax_op
+def scaled_dot_general(
+    lhs: ScaledArray,
+    rhs: ScaledArray,
+    dimension_numbers: Tuple[Tuple[Sequence[int], Sequence[int]], Tuple[Sequence[int], Sequence[int]]],
+    precision: Any = None,
+    preferred_element_type: Optional[DTypeLike] = None,
+) -> ScaledArray:
+    # Checks on `dot_general` arguments. Only supporting a subset right now.
+    ((lhs_contracting_dims, rhs_contracting_dims), (lhs_batch_dims, rhs_batch_dims)) = dimension_numbers
+    assert len(lhs_batch_dims) == 0
+    assert len(rhs_batch_dims) == 0
+    assert len(lhs_contracting_dims) == 1
+    assert len(rhs_contracting_dims) == 1
+
+    contracting_dim_size = lhs.shape[lhs_contracting_dims[0]]
+    # "unit scaling" rule, based on the contracting axis.
+    outscale_dtype = jnp.promote_types(lhs.scale.dtype, rhs.scale.dtype)
+    contracting_rescale = np.sqrt(contracting_dim_size)
+    output_scale = lhs.scale * rhs.scale * contracting_rescale.astype(outscale_dtype)
+    # NOTE: need to be a bit careful about scale promotion?
+    output_data = lax.dot_general(
+        lhs.data,
+        rhs.data,
+        dimension_numbers=dimension_numbers,
+        precision=precision,
+        preferred_element_type=preferred_element_type,
+    )
+    output_data = output_data / contracting_rescale.astype(output_data.dtype)
+    return ScaledArray(output_data, output_scale)
+
+
+@core.register_scaled_lax_op
+def scaled_conv_general_dilated(lhs: ScaledArray, rhs: ScaledArray, **params) -> ScaledArray:
+    assert isinstance(lhs, ScaledArray)
+    assert isinstance(rhs, ScaledArray)
+    data = lax.conv_general_dilated_p.bind(lhs.data, rhs.data, **params)
+    # FIXME: should we change scaling if e.g. window > 3?
+    return ScaledArray(data, lhs.scale * rhs.scale)
+
+
+@core.register_scaled_lax_op
+def scaled_reduce_sum(val: ScaledArray, axes: Tuple[int]) -> ScaledArray:
+    assert isinstance(val, ScaledArray)
+    shape = val.shape
+    axes_size = np.array([shape[idx] for idx in axes])
+    # Rescale data component following reduction axes.
+    axes_rescale = np.sqrt(np.prod(axes_size))
+    data = lax.reduce_sum_p.bind(val.data, axes=axes) / axes_rescale.astype(val.data.dtype)
+    outscale = val.scale * axes_rescale.astype(val.scale.dtype)
+    return ScaledArray(data, outscale)
+
+
+@core.register_scaled_lax_op
+def scaled_reduce_prod(val: ScaledArray, axes: Tuple[int]) -> ScaledArray:
+    assert isinstance(val, ScaledArray)
+    shape = val.shape
+    data = lax.reduce_prod_p.bind(val.data, axes=axes)
+    axes_size = np.prod(np.array([shape[idx] for idx in axes]))
+    scale = lax.integer_pow(val.scale, axes_size)
+    return ScaledArray(data, scale)
+
+
+@core.register_scaled_lax_op
+def scaled_reduce_max(val: ScaledArray, axes: Tuple[int]) -> ScaledArray:
+    assert isinstance(val, ScaledArray)
+    data = lax.reduce_max_p.bind(val.data, axes=axes)
+    # unchanged scaling.
+    return ScaledArray(data, val.scale)
+
+
+@core.register_scaled_lax_op
+def scaled_reduce_min(val: ScaledArray, axes: Tuple[int]) -> ScaledArray:
+    assert isinstance(val, ScaledArray)
+    data = lax.reduce_min_p.bind(val.data, axes=axes)
+    # unchanged scaling.
+    return ScaledArray(data, val.scale)
+
+
+@core.register_scaled_lax_op
+def scaled_reduce_window_sum(
+    val: ScaledArray,
+    window_dimensions: Any,
+    window_strides: Any,
+    padding: Any,
+    base_dilation: Any,
+    window_dilation: Any,
+) -> ScaledArray:
+    assert isinstance(val, ScaledArray)
+    data = lax.reduce_window_sum_p.bind(
+        val.data,
+        window_dimensions=window_dimensions,
+        window_strides=window_strides,
+        padding=padding,
+        base_dilation=base_dilation,
+        window_dilation=window_dilation,
+    )
+    # FIXME: should we change scaling if e.g. window > 3?
+    return ScaledArray(data, val.scale)
+
+
+@core.register_scaled_lax_op
+def scaled_reduce_window_min(
+    val: ScaledArray,
+    window_dimensions: Any,
+    window_strides: Any,
+    padding: Any,
+    base_dilation: Any,
+    window_dilation: Any,
+) -> ScaledArray:
+    assert isinstance(val, ScaledArray)
+    data = lax.reduce_window_min_p.bind(
+        val.data,
+        window_dimensions=window_dimensions,
+        window_strides=window_strides,
+        padding=padding,
+        base_dilation=base_dilation,
+        window_dilation=window_dilation,
+    )
+    # unchanged scaling.
+    return ScaledArray(data, val.scale)
+
+
+@core.register_scaled_lax_op
+def scaled_reduce_window_max(
+    val: ScaledArray,
+    window_dimensions: Any,
+    window_strides: Any,
+    padding: Any,
+    base_dilation: Any,
+    window_dilation: Any,
+) -> ScaledArray:
+    assert isinstance(val, ScaledArray)
+    data = lax.reduce_window_max_p.bind(
+        val.data,
+        window_dimensions=window_dimensions,
+        window_strides=window_strides,
+        padding=padding,
+        base_dilation=base_dilation,
+        window_dilation=window_dilation,
+    )
+    # unchanged scaling.
+    return ScaledArray(data, val.scale)

--- a/tests/lax/test_scaled_ops_common.py
+++ b/tests/lax/test_scaled_ops_common.py
@@ -17,13 +17,9 @@ from jax_scaled_arithmetics.lax import (
     scaled_broadcast_in_dim,
     scaled_concatenate,
     scaled_convert_element_type,
-    scaled_div,
-    scaled_dot_general,
     scaled_is_finite,
-    scaled_mul,
     scaled_pad,
     scaled_reduce_precision,
-    scaled_reduce_window_sum,
     scaled_reshape,
     scaled_rev,
     scaled_select_n,
@@ -136,152 +132,6 @@ class ScaledTranslationPrimitivesTests(chex.TestCase):
         out = scaled_translation(x, axes=(0,), index_dtype=np.int32)
         assert isinstance(out, Array)
         npt.assert_array_equal(out, expected_out)
-
-    @parameterized.parameters(
-        {"ldtype": np.float32, "rdtype": np.float32},
-        # {"ldtype": np.float32, "rdtype": np.float16}, # Not supported in JAX 0.3.x
-        # {"ldtype": np.float16, "rdtype": np.float32},
-        {"ldtype": np.float16, "rdtype": np.float16},
-    )
-    def test__scaled_dot_general__proper_scaling(self, ldtype, rdtype):
-        lhs = scaled_array(self.rs.rand(3, 5), 2.0, dtype=ldtype)
-        rhs = scaled_array(self.rs.rand(5, 2), 3.0, dtype=rdtype)
-
-        dimension_numbers = (((1,), (0,)), ((), ()))
-        out = scaled_dot_general(lhs, rhs, dimension_numbers)
-        expected_out = lax.dot_general(np.asarray(lhs), np.asarray(rhs), dimension_numbers)
-
-        assert isinstance(out, ScaledArray)
-        assert out.dtype == expected_out.dtype
-        assert out.scale.dtype == np.float32  # TODO: more test coverage.
-        npt.assert_almost_equal(out.scale, lhs.scale * rhs.scale * np.sqrt(5))
-        npt.assert_array_almost_equal(out, expected_out, decimal=2)
-
-
-class ScaledTranslationUnaryOpsTests(chex.TestCase):
-    def setUp(self):
-        super().setUp()
-        # Use random state for reproducibility!
-        self.rs = np.random.RandomState(42)
-
-    @chex.variants(with_jit=True, without_jit=True)
-    @parameterized.parameters(
-        {"prim": lax.exp_p, "dtype": np.float16, "expected_scale": 1.0},  # FIXME!
-        {"prim": lax.log_p, "dtype": np.float16, "expected_scale": 1.0},  # FIXME!
-        {"prim": lax.neg_p, "dtype": np.float16, "expected_scale": 2.0},
-        {"prim": lax.abs_p, "dtype": np.float16, "expected_scale": 2.0},
-        {"prim": lax.cos_p, "dtype": np.float16, "expected_scale": 1.0},
-        {"prim": lax.sin_p, "dtype": np.float16, "expected_scale": 1.0},
-    )
-    def test__scaled_unary_op__proper_result_and_scaling(self, prim, dtype, expected_scale):
-        scaled_op, _ = find_registered_scaled_op(prim)
-        val = scaled_array(self.rs.rand(3, 5), 2.0, dtype=dtype)
-        out = self.variant(scaled_op)(val)
-        expected_output = prim.bind(np.asarray(val))
-        assert isinstance(out, ScaledArray)
-        assert out.dtype == val.dtype
-        assert out.scale.dtype == val.scale.dtype
-        npt.assert_almost_equal(out.scale, expected_scale)
-        npt.assert_array_almost_equal(out, expected_output)
-
-
-class ScaledTranslationBinaryOpsTests(chex.TestCase):
-    def setUp(self):
-        super().setUp()
-        # Use random state for reproducibility!
-        self.rs = np.random.RandomState(42)
-
-    @chex.variants(with_jit=True, without_jit=True)
-    @parameterized.product(
-        prim=[lax.add_p, lax.sub_p, lax.mul_p, lax.div_p, lax.min_p, lax.max_p],
-        dtype=[np.float16, np.float32],
-        sdtype=[np.float16, np.float32],
-    )
-    def test__scaled_binary_op__proper_result_and_promotion(self, prim, dtype, sdtype):
-        scaled_op, _ = find_registered_scaled_op(prim)
-        # NOTE: direct construction to avoid weirdity between NumPy array and scalar!
-        x = ScaledArray(np.array([-1.0, 2.0], dtype), sdtype(3.0))
-        y = ScaledArray(np.array([1.5, 4.5], dtype), sdtype(2.0))
-        # Ensure scale factor has the right dtype.
-        assert x.scale.dtype == sdtype
-        assert y.scale.dtype == sdtype
-
-        z = self.variant(scaled_op)(x, y)
-        expected_z = prim.bind(np.asarray(x), np.asarray(y))
-
-        assert z.dtype == x.dtype
-        assert z.scale.dtype == sdtype
-        npt.assert_array_almost_equal(z, expected_z, decimal=3)
-
-    @parameterized.parameters(
-        {"prim": lax.add_p},
-        {"prim": lax.sub_p},
-    )
-    def test__scaled_addsub__proper_scaling(self, prim):
-        scaled_op, _ = find_registered_scaled_op(prim)
-        x = scaled_array([-1.0, 2.0], 3.0, dtype=np.float32)
-        y = scaled_array([1.5, 4.5], 2.0, dtype=np.float32)
-        z = scaled_op(x, y)
-        assert isinstance(z, ScaledArray)
-        assert z.dtype == x.dtype
-        npt.assert_almost_equal(z.scale, np.sqrt(4.0 + 9.0))
-
-    def test__scaled_mul__proper_scaling(self):
-        x = scaled_array([-2.0, 2.0], 3, dtype=np.float32)
-        y = scaled_array([1.5, 1.5], 2, dtype=np.float32)
-        z = scaled_mul(x, y)
-        assert isinstance(z, ScaledArray)
-        assert z.scale == 6
-        npt.assert_array_almost_equal(z, np.asarray(x) * np.asarray(y))
-
-    def test__scaled_div__proper_scaling(self):
-        x = scaled_array([-2.0, 2.0], 3.0, dtype=np.float32)
-        y = scaled_array([1.5, 1.5], 2.0, dtype=np.float32)
-        z = scaled_div(x, y)
-        assert isinstance(z, ScaledArray)
-        assert z.scale == 1.5
-        npt.assert_array_almost_equal(z, np.asarray(x) / np.asarray(y))
-
-
-class ScaledTranslationReducePrimitivesTests(chex.TestCase):
-    def setUp(self):
-        super().setUp()
-        # Use random state for reproducibility!
-        self.rs = np.random.RandomState(42)
-
-    @parameterized.parameters(
-        {"reduce_prim": lax.reduce_sum_p, "expected_scale": 2 * np.sqrt(5)},
-        {"reduce_prim": lax.reduce_prod_p, "expected_scale": 2**5},
-        {"reduce_prim": lax.reduce_min_p, "expected_scale": 2},
-        {"reduce_prim": lax.reduce_max_p, "expected_scale": 2},
-    )
-    def test__scaled_reduce__single_axis__proper_scaling(self, reduce_prim, expected_scale):
-        axes = (0,)
-        # NOTE: float16 useful for checking dtype promotion!
-        val = scaled_array(self.rs.rand(5), 2.0, dtype=np.float16)
-        scaled_reduce_op, _ = find_registered_scaled_op(reduce_prim)
-        out = scaled_reduce_op(val, axes=axes)
-
-        assert isinstance(out, ScaledArray)
-        assert out.shape == ()
-        assert out.dtype == val.dtype
-        npt.assert_almost_equal(out.scale, expected_scale)
-        npt.assert_array_almost_equal(out, reduce_prim.bind(np.asarray(val), axes=axes))
-
-    def test__scaled_reduce_window_sum__proper_result(self):
-        val = scaled_array(self.rs.rand(5), 2.0, dtype=np.float32)
-        out = scaled_reduce_window_sum(
-            val,
-            window_dimensions=(3,),
-            window_strides=(1,),
-            padding=((1, 0),),
-            base_dilation=(1,),
-            window_dilation=(1,),
-        )
-        assert isinstance(out, ScaledArray)
-        assert out.shape == (4,)
-        assert out.dtype == val.dtype
-        npt.assert_almost_equal(out.scale, val.scale)
 
 
 class ScaledTranslationBooleanPrimitivesTests(chex.TestCase):

--- a/tests/lax/test_scaled_ops_l2.py
+++ b/tests/lax/test_scaled_ops_l2.py
@@ -1,0 +1,162 @@
+# Copyright (c) 2023 Graphcore Ltd. All rights reserved.
+import chex
+import numpy as np
+import numpy.testing as npt
+from absl.testing import parameterized
+from jax import lax
+
+from jax_scaled_arithmetics.core import ScaledArray, find_registered_scaled_op, scaled_array
+from jax_scaled_arithmetics.lax import scaled_div, scaled_dot_general, scaled_mul, scaled_reduce_window_sum
+
+
+class ScaledTranslationDotPrimitivesTests(chex.TestCase):
+    def setUp(self):
+        super().setUp()
+        # Use random state for reproducibility!
+        self.rs = np.random.RandomState(42)
+
+    @parameterized.parameters(
+        {"ldtype": np.float32, "rdtype": np.float32},
+        # {"ldtype": np.float32, "rdtype": np.float16}, # Not supported in JAX 0.3.x
+        # {"ldtype": np.float16, "rdtype": np.float32},
+        {"ldtype": np.float16, "rdtype": np.float16},
+    )
+    def test__scaled_dot_general__proper_scaling(self, ldtype, rdtype):
+        lhs = scaled_array(self.rs.rand(3, 5), 2.0, dtype=ldtype)
+        rhs = scaled_array(self.rs.rand(5, 2), 3.0, dtype=rdtype)
+
+        dimension_numbers = (((1,), (0,)), ((), ()))
+        out = scaled_dot_general(lhs, rhs, dimension_numbers)
+        expected_out = lax.dot_general(np.asarray(lhs), np.asarray(rhs), dimension_numbers)
+
+        assert isinstance(out, ScaledArray)
+        assert out.dtype == expected_out.dtype
+        assert out.scale.dtype == np.float32  # TODO: more test coverage.
+        npt.assert_almost_equal(out.scale, lhs.scale * rhs.scale * np.sqrt(5))
+        npt.assert_array_almost_equal(out, expected_out, decimal=2)
+
+
+class ScaledTranslationUnaryOpsTests(chex.TestCase):
+    def setUp(self):
+        super().setUp()
+        # Use random state for reproducibility!
+        self.rs = np.random.RandomState(42)
+
+    @chex.variants(with_jit=True, without_jit=True)
+    @parameterized.parameters(
+        {"prim": lax.exp_p, "dtype": np.float16, "expected_scale": 1.0},  # FIXME!
+        {"prim": lax.log_p, "dtype": np.float16, "expected_scale": 1.0},  # FIXME!
+        {"prim": lax.neg_p, "dtype": np.float16, "expected_scale": 2.0},
+        {"prim": lax.abs_p, "dtype": np.float16, "expected_scale": 2.0},
+        {"prim": lax.cos_p, "dtype": np.float16, "expected_scale": 1.0},
+        {"prim": lax.sin_p, "dtype": np.float16, "expected_scale": 1.0},
+    )
+    def test__scaled_unary_op__proper_result_and_scaling(self, prim, dtype, expected_scale):
+        scaled_op, _ = find_registered_scaled_op(prim)
+        val = scaled_array(self.rs.rand(3, 5), 2.0, dtype=dtype)
+        out = self.variant(scaled_op)(val)
+        expected_output = prim.bind(np.asarray(val))
+        assert isinstance(out, ScaledArray)
+        assert out.dtype == val.dtype
+        assert out.scale.dtype == val.scale.dtype
+        npt.assert_almost_equal(out.scale, expected_scale)
+        npt.assert_array_almost_equal(out, expected_output)
+
+
+class ScaledTranslationBinaryOpsTests(chex.TestCase):
+    def setUp(self):
+        super().setUp()
+        # Use random state for reproducibility!
+        self.rs = np.random.RandomState(42)
+
+    @chex.variants(with_jit=True, without_jit=True)
+    @parameterized.product(
+        prim=[lax.add_p, lax.sub_p, lax.mul_p, lax.div_p, lax.min_p, lax.max_p],
+        dtype=[np.float16, np.float32],
+        sdtype=[np.float16, np.float32],
+    )
+    def test__scaled_binary_op__proper_result_and_promotion(self, prim, dtype, sdtype):
+        scaled_op, _ = find_registered_scaled_op(prim)
+        # NOTE: direct construction to avoid weirdity between NumPy array and scalar!
+        x = ScaledArray(np.array([-1.0, 2.0], dtype), sdtype(3.0))
+        y = ScaledArray(np.array([1.5, 4.5], dtype), sdtype(2.0))
+        # Ensure scale factor has the right dtype.
+        assert x.scale.dtype == sdtype
+        assert y.scale.dtype == sdtype
+
+        z = self.variant(scaled_op)(x, y)
+        expected_z = prim.bind(np.asarray(x), np.asarray(y))
+
+        assert z.dtype == x.dtype
+        assert z.scale.dtype == sdtype
+        npt.assert_array_almost_equal(z, expected_z, decimal=3)
+
+    @parameterized.parameters(
+        {"prim": lax.add_p},
+        {"prim": lax.sub_p},
+    )
+    def test__scaled_addsub__proper_scaling(self, prim):
+        scaled_op, _ = find_registered_scaled_op(prim)
+        x = scaled_array([-1.0, 2.0], 3.0, dtype=np.float32)
+        y = scaled_array([1.5, 4.5], 2.0, dtype=np.float32)
+        z = scaled_op(x, y)
+        assert isinstance(z, ScaledArray)
+        assert z.dtype == x.dtype
+        npt.assert_almost_equal(z.scale, np.sqrt(4.0 + 9.0))
+
+    def test__scaled_mul__proper_scaling(self):
+        x = scaled_array([-2.0, 2.0], 3, dtype=np.float32)
+        y = scaled_array([1.5, 1.5], 2, dtype=np.float32)
+        z = scaled_mul(x, y)
+        assert isinstance(z, ScaledArray)
+        assert z.scale == 6
+        npt.assert_array_almost_equal(z, np.asarray(x) * np.asarray(y))
+
+    def test__scaled_div__proper_scaling(self):
+        x = scaled_array([-2.0, 2.0], 3.0, dtype=np.float32)
+        y = scaled_array([1.5, 1.5], 2.0, dtype=np.float32)
+        z = scaled_div(x, y)
+        assert isinstance(z, ScaledArray)
+        assert z.scale == 1.5
+        npt.assert_array_almost_equal(z, np.asarray(x) / np.asarray(y))
+
+
+class ScaledTranslationReducePrimitivesTests(chex.TestCase):
+    def setUp(self):
+        super().setUp()
+        # Use random state for reproducibility!
+        self.rs = np.random.RandomState(42)
+
+    @parameterized.parameters(
+        {"reduce_prim": lax.reduce_sum_p, "expected_scale": 2 * np.sqrt(5)},
+        {"reduce_prim": lax.reduce_prod_p, "expected_scale": 2**5},
+        {"reduce_prim": lax.reduce_min_p, "expected_scale": 2},
+        {"reduce_prim": lax.reduce_max_p, "expected_scale": 2},
+    )
+    def test__scaled_reduce__single_axis__proper_scaling(self, reduce_prim, expected_scale):
+        axes = (0,)
+        # NOTE: float16 useful for checking dtype promotion!
+        val = scaled_array(self.rs.rand(5), 2.0, dtype=np.float16)
+        scaled_reduce_op, _ = find_registered_scaled_op(reduce_prim)
+        out = scaled_reduce_op(val, axes=axes)
+
+        assert isinstance(out, ScaledArray)
+        assert out.shape == ()
+        assert out.dtype == val.dtype
+        npt.assert_almost_equal(out.scale, expected_scale)
+        npt.assert_array_almost_equal(out, reduce_prim.bind(np.asarray(val), axes=axes))
+
+    def test__scaled_reduce_window_sum__proper_result(self):
+        val = scaled_array(self.rs.rand(5), 2.0, dtype=np.float32)
+        out = scaled_reduce_window_sum(
+            val,
+            window_dimensions=(3,),
+            window_strides=(1,),
+            padding=((1, 0),),
+            base_dilation=(1,),
+            window_dilation=(1,),
+        )
+        assert isinstance(out, ScaledArray)
+        assert out.shape == (4,)
+        assert out.dtype == val.dtype
+        npt.assert_almost_equal(out.scale, val.scale)


### PR DESCRIPTION
Properly separating common ops, independent of the strategy, and L2/Gaussian scaling ops/translation (which potentially can be altered).