### PR TITLE
Use power-of-two scaling in autoscale scaled translation ops rules.

### DIFF
--- a/jax_scaled_arithmetics/__init__.py
+++ b/jax_scaled_arithmetics/__init__.py
@@ -1,4 +1,13 @@
 # Copyright (c) 2023 Graphcore Ltd. All rights reserved.
 from . import lax
 from ._version import __version__
-from .core import ScaledArray, as_scaled_array, asarray, autoscale, debug_callback, scaled_array  # noqa: F401
+from .core import (  # noqa: F401
+    AutoScaleConfig,
+    Pow2RoundMode,
+    ScaledArray,
+    as_scaled_array,
+    asarray,
+    autoscale,
+    debug_callback,
+    scaled_array,
+)

--- a/jax_scaled_arithmetics/core/__init__.py
+++ b/jax_scaled_arithmetics/core/__init__.py
@@ -9,14 +9,18 @@ from .datatype import (  # noqa: F401
     is_scaled_leaf,
     is_static_one_scalar,
     is_static_zero,
+    make_scaled_scalar,
     scaled_array,
 )
 from .debug import debug_callback  # noqa: F401
 from .interpreters import (  # noqa: F401
+    AutoScaleConfig,
     ScaledPrimitiveType,
     autoscale,
     find_registered_scaled_op,
+    get_autoscale_config,
     register_scaled_lax_op,
     register_scaled_op,
 )
 from .typing import Array, ArrayTypes, get_numpy_api  # noqa: F401
+from .utils import Pow2RoundMode, pow2_round, pow2_round_down, pow2_round_up  # noqa: F401

--- a/jax_scaled_arithmetics/core/typing.py
+++ b/jax_scaled_arithmetics/core/typing.py
@@ -19,10 +19,13 @@ else:
 def get_numpy_api(val: Any) -> Any:
     """Get the Numpy API corresponding to an array.
 
+    Using the NumPy API whenever possible when tracing a JAX graph
+    allows for simple constant folding optimization.
+
     JAX or classic Numpy supported.
     """
-    if isinstance(val, jax.Array):
-        return jnp
-    elif isinstance(val, (np.ndarray, np.number)):
+    if isinstance(val, (np.ndarray, np.number)):
         return np
+    if isinstance(val, ArrayTypes):
+        return jnp
     raise NotImplementedError(f"Unsupported input type '{type(val)}'. No matching Numpy API.")

--- a/jax_scaled_arithmetics/core/utils.py
+++ b/jax_scaled_arithmetics/core/utils.py
@@ -1,0 +1,79 @@
+# Copyright (c) 2023 Graphcore Ltd. All rights reserved.
+from enum import IntEnum
+from typing import Any, Dict
+
+import numpy as np
+from numpy.typing import NDArray
+
+from .typing import Array, get_numpy_api
+
+# Exponent bits masking.
+_exponent_bits_mask: Dict[Any, NDArray[Any]] = {
+    np.dtype(np.float16): np.packbits(np.array([0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 0, 0], dtype=np.uint8)).view(
+        np.int16
+    ),
+    np.dtype(np.float32): np.packbits(
+        np.array(
+            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1],
+            dtype=np.uint8,
+        )
+    ).view(np.int32),
+    np.dtype(np.float64): np.array(np.inf, np.float64).view(np.int64),
+}
+"""Exponents bit masking: explicit bitmask to keep only exponent bits in floating point values.
+
+NOTE: normally should also correspond to `np.inf` value for FP16 and FP32.
+"""
+
+
+class Pow2RoundMode(IntEnum):
+    """Power-of-two supported rounded mode."""
+
+    NONE = 0
+    DOWN = 1
+    UP = 2
+    STOCHASTIC = 3
+
+
+def get_mantissa(val: Array) -> Array:
+    """Extract the mantissa of an array, masking the exponent.
+
+    Similar to `numpy.frexp`, but with implicit bit to be consistent with
+    `pow2_round_down`.
+    """
+    np_api = get_numpy_api(val)
+    # TODO: implement using bitmasking?
+    mantissa_val, _ = np_api.frexp(val)
+    # Re-add the implicit bit to be consistent with `pow2_round_down`
+    mantissa_val = mantissa_val * np.array(2, dtype=val.dtype)
+    return mantissa_val
+
+
+def pow2_round_down(val: Array) -> Array:
+    """Round down to the closest power of 2."""
+    np_api = get_numpy_api(val)
+    exponent_mask = _exponent_bits_mask[val.dtype]
+    intdtype = exponent_mask.dtype
+    pow2_val = np_api.bitwise_and(val.view(intdtype), exponent_mask).view(val.dtype).reshape(val.shape)
+    return pow2_val
+
+
+def pow2_round_up(val: Array) -> Array:
+    """Round up to the closest power of 2.
+    NOTE: may overflow to inf.
+    """
+    # FIXME: rounding when already a power of 2.
+    # Should do additional masking to check that.
+    pow2_val = pow2_round_down(val) * np.array(2, dtype=val.dtype)
+    return pow2_val
+
+
+def pow2_round(val: Array, mode: Pow2RoundMode = Pow2RoundMode.DOWN) -> Array:
+    """Power-of-two rounding."""
+    if mode == Pow2RoundMode.NONE:
+        return val
+    elif mode == Pow2RoundMode.DOWN:
+        return pow2_round_down(val)
+    elif mode == Pow2RoundMode.UP:
+        return pow2_round_up(val)
+    raise NotImplementedError(f"Unsupported power-of-2 rounding mode '{mode}'.")

--- a/jax_scaled_arithmetics/lax/scaled_ops_common.py
+++ b/jax_scaled_arithmetics/lax/scaled_ops_common.py
@@ -85,7 +85,7 @@ def scaled_reduce_precision(A: ScaledArray, exponent_bits: int, mantissa_bits: i
 def scaled_concatenate(operands: Sequence[ScaledArray], dimension: int) -> ScaledArray:
     # TODO: inputs checking (dtype and cie).
     scales = jnp.array([v.scale for v in operands])
-    # Max rescaling of the collection of operands.
+    # Max rescaling of the collection of operands. Preserving pow2 scaling.
     # TODO: explore alternative strategies?
     outdtype = operands[0].dtype
     scale_max = jnp.max(scales)

--- a/tests/core/test_utils.py
+++ b/tests/core/test_utils.py
@@ -1,0 +1,56 @@
+# Copyright (c) 2023 Graphcore Ltd. All rights reserved.
+import chex
+import numpy as np
+import numpy.testing as npt
+from absl.testing import parameterized
+
+from jax_scaled_arithmetics.core import pow2_round_down, pow2_round_up
+from jax_scaled_arithmetics.core.utils import _exponent_bits_mask, get_mantissa
+
+
+class Pow2RoundingUtilTests(chex.TestCase):
+    @parameterized.parameters(
+        {"dtype": np.float16},
+        {"dtype": np.float32},
+    )
+    def test__exponent_bitmask__inf_value(self, dtype):
+        val = _exponent_bits_mask[np.dtype(dtype)].view(dtype)
+        expected_val = dtype(np.inf)
+        npt.assert_equal(val, expected_val)
+
+    @parameterized.product(
+        val_mant=[(1, 1), (2.1, 1.05), (0, 0), (0.51, 1.02), (65504, 1.9990234375)],
+        dtype=[np.float16, np.float32, np.float64],
+    )
+    def test__get_mantissa__proper_value__multi_dtypes(self, val_mant, dtype):
+        val, mant = dtype(val_mant[0]), dtype(val_mant[1])
+        val_mant = get_mantissa(val)
+        assert val_mant.dtype == val.dtype
+        assert val_mant.shape == ()
+        assert type(val_mant) in {type(val), np.ndarray}
+        npt.assert_equal(val_mant, mant)
+        # Should be consistent with `pow2_round_down`. bitwise, not approximation.
+        npt.assert_equal(mant * pow2_round_down(val), val)
+
+    @parameterized.product(
+        val_exp=[(0, 0), (1, 1), (2.1, 2), (0.3, 0.25), (0.51, 0.5), (65500, 32768)],
+        dtype=[np.float16, np.float32, np.float64],
+    )
+    def test__pow2_round_down__proper_rounding__multi_dtypes(self, val_exp, dtype):
+        val, exp = dtype(val_exp[0]), dtype(val_exp[1])
+        pow2_val = pow2_round_down(val)
+        assert pow2_val.dtype == val.dtype
+        assert pow2_val.shape == ()
+        assert type(pow2_val) in {type(val), np.ndarray}
+        npt.assert_equal(pow2_val, exp)
+
+    @parameterized.product(
+        val_exp=[(2.1, 4), (0.3, 0.5), (0.51, 1), (17000, 32768)],
+        dtype=[np.float16],
+    )
+    def test__pow2_round_up__proper_rounding__multi_dtypes(self, val_exp, dtype):
+        val, exp = dtype(val_exp[0]), dtype(val_exp[1])
+        pow2_val = pow2_round_up(val)
+        assert pow2_val.dtype == val.dtype
+        assert type(pow2_val) in {type(val), np.ndarray}
+        npt.assert_equal(pow2_val, exp)

--- a/tests/lax/test_scaled_ops_common.py
+++ b/tests/lax/test_scaled_ops_common.py
@@ -43,7 +43,8 @@ class ScaledTranslationPrimitivesTests(chex.TestCase):
                 host_values.append(v)
 
         def fn(a):
-            debug_callback(callback, a, a * 3)
+            # NOTE: multiplying by a power of 2 to simplify test.
+            debug_callback(callback, a, a * 4)
             return a
 
         x = scaled_array(self.rs.rand(5), 2, dtype=np.float16)
@@ -55,7 +56,7 @@ class ScaledTranslationPrimitivesTests(chex.TestCase):
             assert isinstance(sv, ScaledArray)
             npt.assert_array_equal(sv.data, x.data)
         npt.assert_array_equal(host_values[0].scale, x.scale)
-        npt.assert_array_equal(host_values[1].scale, x.scale * 3)
+        npt.assert_array_equal(host_values[1].scale, x.scale * 4)
 
     def test__scaled_broadcast_in_dim__proper_scaling(self):
         x = scaled_array(self.rs.rand(5), 2, dtype=np.float32)


### PR DESCRIPTION
As shown in https://github.com/graphcore-research/jax-scaled-arithmetics/issues/60 issue, propagating non power-of-two scaling factors can decrease training accuracy in low precision (typically in FP16).
The additional rescaling operations will introduce non-negligible floating point accumulated errors.

Ths PR is adding the option to round the scale to a power-of-two in scaled translation. Supporting at the moment only rounding up and down. The rounding mode can be modified in the config dataclass `AutoScaleConfig`.

Scaled translations updated are: `dot_general`, `add`, `sub` and `reduce_sum`.

Finally, when implicitely converting scalars to scaled arrays, the method `make_scaled_scaled` now splits the input mantissa and exponent between data and scale.