### PR TITLE
Fix broken MNIST classifier training.

### DIFF
--- a/jax_scaled_arithmetics/core/__init__.py
+++ b/jax_scaled_arithmetics/core/__init__.py
@@ -5,6 +5,7 @@ from .datatype import (  # noqa: F401
     Shape,
     as_scaled_array,
     asarray,
+    get_scale_dtype,
     is_scaled_leaf,
     is_static_one_scalar,
     is_static_zero,

--- a/jax_scaled_arithmetics/core/datatype.py
+++ b/jax_scaled_arithmetics/core/datatype.py
@@ -226,3 +226,10 @@ def is_static_one_scalar(val: Array) -> Union[bool, np.bool_]:
     elif isinstance(val, ScaledArray) and val.size == 1:
         return is_static_one_scalar(val.data) and is_static_one_scalar(val.scale)
     return False
+
+
+def get_scale_dtype(val: Any) -> DTypeLike:
+    """Get the scale dtype. Compatible with arrays and scaled arrays."""
+    if isinstance(val, ScaledArray):
+        return val.scale.dtype
+    return val.dtype

--- a/jax_scaled_arithmetics/lax/scaled_ops_common.py
+++ b/jax_scaled_arithmetics/lax/scaled_ops_common.py
@@ -8,7 +8,15 @@ import numpy as np
 from jax import lax
 
 from jax_scaled_arithmetics import core
-from jax_scaled_arithmetics.core import Array, DTypeLike, ScaledArray, Shape, as_scaled_array, is_static_zero
+from jax_scaled_arithmetics.core import (
+    Array,
+    DTypeLike,
+    ScaledArray,
+    Shape,
+    as_scaled_array,
+    get_scale_dtype,
+    is_static_zero,
+)
 
 from .base_scaling_primitives import scaled_set_scaling
 
@@ -233,7 +241,7 @@ def scaled_log(val: ScaledArray) -> ScaledArray:
 
 @core.register_scaled_lax_op
 def scaled_select_n(which: Array, *cases: ScaledArray) -> ScaledArray:
-    outscale_dtype = promote_types(*[v.scale.dtype for v in cases])
+    outscale_dtype = promote_types(*[get_scale_dtype(v) for v in cases])
     outscale = np.array(1, dtype=outscale_dtype)
     return scaled_op_default_translation(lax.select_n_p, [which, *cases], outscale=outscale)
 

--- a/tests/core/test_datatype.py
+++ b/tests/core/test_datatype.py
@@ -11,6 +11,7 @@ from jax_scaled_arithmetics.core import (
     ScaledArray,
     as_scaled_array,
     asarray,
+    get_scale_dtype,
     is_scaled_leaf,
     is_static_one_scalar,
     is_static_zero,
@@ -237,3 +238,11 @@ class ScaledArrayDataclassTests(chex.TestCase):
         r = is_static_one_scalar(asarray(val))
         assert isinstance(r, (bool, np.bool_))
         assert r == result
+
+    @parameterized.parameters(
+        {"val": np.float32(2), "result": np.float32},
+        {"val": ScaledArray(np.array(2.0), np.float16(3)), "result": np.float16},
+    )
+    def test__get_scale_dtype__proper_dtype(self, val, result):
+        sdtype = get_scale_dtype(val)
+        assert sdtype == result


### PR DESCRIPTION
Adding a function `get_scale_dtype` compatible with scaled arrays and normal arrays.