### PR TITLE
Add ScaledArray debug capture/print methods

### DIFF
--- a/jax_scaled_arithmetics/__init__.py
+++ b/jax_scaled_arithmetics/__init__.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2023 Graphcore Ltd. All rights reserved.
-from . import lax
+from . import lax, ops
 from ._version import __version__
 from .core import (  # noqa: F401
     AutoScaleConfig,

--- a/jax_scaled_arithmetics/ops/__init__.py
+++ b/jax_scaled_arithmetics/ops/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2023 Graphcore Ltd. All rights reserved.
+from .debug import debug_callback, debug_callback_grad, debug_print, debug_print_grad  # noqa: F401

--- a/jax_scaled_arithmetics/ops/debug.py
+++ b/jax_scaled_arithmetics/ops/debug.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2023 Graphcore Ltd. All rights reserved.
+from functools import partial
+
+import jax
+
+from jax_scaled_arithmetics.core import debug_callback
+
+
+@partial(jax.custom_vjp, nondiff_argnums=(0,))
+def debug_callback_grad(f, *args):
+    """Custom callback, called on gradients."""
+    return args
+
+
+def debug_callback_grad_fwd(f, *args):
+    return args, None
+
+
+def debug_callback_grad_bwd(f, _, args_grad):
+    debug_callback(f, *args_grad)
+    return args_grad
+
+
+debug_callback_grad.defvjp(debug_callback_grad_fwd, debug_callback_grad_bwd)
+
+
+def debug_print(fmt: str, *args):
+    """Debug print of a collection of tensors."""
+    debug_callback(lambda *args: print(fmt.format(*args)), *args)
+    return args
+
+
+def debug_print_grad(fmt: str, *args):
+    """Debug print of gradients of a collection of tensors."""
+    return debug_callback_grad(lambda *args: print(fmt.format(*args)), *args)

--- a/tests/ops/test_debug.py
+++ b/tests/ops/test_debug.py
@@ -1,0 +1,19 @@
+# Copyright (c) 2023 Graphcore Ltd. All rights reserved.
+import numpy as np
+
+from jax_scaled_arithmetics.core import autoscale, scaled_array
+from jax_scaled_arithmetics.ops import debug_print
+
+
+def test__debug_print__scaled_arrays(capfd):
+    fmt = "INPUTS: {} + {}"
+
+    def debug_print_fn(x):
+        debug_print(fmt, x, x)
+
+    input_scaled = scaled_array([2, 3], 2.0, dtype=np.float32)
+    autoscale(debug_print_fn)(input_scaled)
+    # Check captured stdout and stderr!
+    captured = capfd.readouterr()
+    assert len(captured.err) == 0
+    assert captured.out.strip() == fmt.format(input_scaled, input_scaled)


### PR DESCRIPTION
Adding `debug_callback_grad` and `debug_print(_grad)` to help debugging ML models.