### PR TITLE
Implement ScaledArray unbundling primitive `get_data_scale`.

### DIFF
--- a/jax_scaled_arithmetics/lax/__init__.py
+++ b/jax_scaled_arithmetics/lax/__init__.py
@@ -1,4 +1,11 @@
 # Copyright (c) 2023 Graphcore Ltd. All rights reserved.
-from .base_scaling_primitives import set_scaling, set_scaling_p, stop_scaling, stop_scaling_p  # noqa: F401
+from .base_scaling_primitives import (  # noqa: F401
+    get_data_scale,
+    get_data_scale_p,
+    set_scaling,
+    set_scaling_p,
+    stop_scaling,
+    stop_scaling_p,
+)
 from .scaled_ops_common import *  # noqa: F401, F403
 from .scaled_ops_l2 import *  # noqa: F401, F403


### PR DESCRIPTION
Allowing unbundling of a ScaledArray into `data` and `scale` components in JAX jitted mode, while being compatible with normal JAX (i.e. just returning a constant 1 for the scale tensor).