### PR TITLE
Fix bug in `get_data_scale` ScaledArray primitive.

### DIFF
--- a/jax_scaled_arithmetics/lax/base_scaling_primitives.py
+++ b/jax_scaled_arithmetics/lax/base_scaling_primitives.py
@@ -146,11 +146,15 @@ def get_data_scale(values: Array) -> Array:
 
 
 def get_data_scale_impl(values: Array) -> Array:
+    if isinstance(values, ScaledArray):
+        return (values.data, values.scale)
     scale = np.ones((), dtype=values.dtype)
     return values, scale
 
 
 def get_data_scale_abstract_eval(values: core.ShapedArray) -> core.ShapedArray:
+    if isinstance(values, ScaledArray):
+        return (values.data, values.scale)
     return values, core.ShapedArray((), dtype=values.dtype)
 
 

--- a/tests/lax/test_base_scaling_primitives.py
+++ b/tests/lax/test_base_scaling_primitives.py
@@ -120,3 +120,14 @@ class GetDataScalePrimitiveTests(chex.TestCase):
         data, scale = fn(arr)
         npt.assert_array_equal(data, arr.data)
         npt.assert_equal(scale, arr.scale)
+
+    def test__get_data_scale_primitive__numpy_input(self):
+        arr = scaled_array([2, 3], 4, dtype=np.float16)
+        # ScaledArray input.
+        data, scale = get_data_scale(arr)
+        npt.assert_array_equal(data, arr.data)
+        npt.assert_array_equal(scale, arr.scale)
+        # Normal numpy array input.
+        data, scale = get_data_scale(np.asarray(arr))
+        npt.assert_array_equal(data, arr)
+        npt.assert_almost_equal(scale, 1)


### PR DESCRIPTION
Previous implementation not supporting properly ScaledArray inputs.