### PR TITLE
Implement max/L1/L2 dynamic rescaling on ScaledArrays.

### DIFF
--- a/jax_scaled_arithmetics/lax/__init__.py
+++ b/jax_scaled_arithmetics/lax/__init__.py
@@ -2,6 +2,7 @@
 from .base_scaling_primitives import (  # noqa: F401
     get_data_scale,
     get_data_scale_p,
+    rebalance,
     set_scaling,
     set_scaling_p,
     stop_scaling,

--- a/jax_scaled_arithmetics/ops/__init__.py
+++ b/jax_scaled_arithmetics/ops/__init__.py
@@ -1,2 +1,10 @@
 # Copyright (c) 2023 Graphcore Ltd. All rights reserved.
 from .debug import debug_callback, debug_callback_grad, debug_print, debug_print_grad  # noqa: F401
+from .rescaling import (  # noqa: F401
+    dynamic_rescale_l1,
+    dynamic_rescale_l1_grad,
+    dynamic_rescale_l2,
+    dynamic_rescale_l2_grad,
+    dynamic_rescale_max,
+    dynamic_rescale_max_grad,
+)

--- a/jax_scaled_arithmetics/ops/rescaling.py
+++ b/jax_scaled_arithmetics/ops/rescaling.py
@@ -1,0 +1,95 @@
+# Copyright (c) 2023 Graphcore Ltd. All rights reserved.
+from functools import partial
+
+import jax
+import numpy as np
+
+from jax_scaled_arithmetics.core import ScaledArray, pow2_round
+from jax_scaled_arithmetics.lax import get_data_scale, rebalance
+
+
+@partial(jax.custom_vjp, nondiff_argnums=(0,))
+def fn_with_identity_grad(f, arg):
+    """Function with identity bwd/grad."""
+    return f(arg)
+
+
+def fn_with_identity_grad_fwd(f, arg):
+    return arg, None
+
+
+def fn_with_identity_grad_bwd(f, _, grad):
+    return (grad,)
+
+
+fn_with_identity_grad.defvjp(fn_with_identity_grad_fwd, fn_with_identity_grad_bwd)
+
+
+@partial(jax.custom_vjp, nondiff_argnums=(0,))
+def fn_on_grad(f, arg):
+    """Apply a function on the gradient/backward pass."""
+    return arg
+
+
+def fn_on_grad_fwd(f, arg):
+    return arg, None
+
+
+def fn_on_grad_bwd(f, _, grad):
+    return (f(grad),)
+
+
+fn_on_grad.defvjp(fn_on_grad_fwd, fn_on_grad_bwd)
+
+
+def dynamic_rescale_max_base(arr: ScaledArray) -> ScaledArray:
+    """Dynamic rescaling of a ScaledArray, using abs-max."""
+    data, scale = get_data_scale(arr)
+    data_sq = jax.lax.abs(data)
+    axes = tuple(range(data.ndim))
+    # Get MAX norm + pow2 rounding.
+    norm = jax.lax.reduce_max_p.bind(data_sq, axes=axes)
+    norm = pow2_round(norm.astype(scale.dtype))
+    # Rebalancing based on norm.
+    return rebalance(arr, norm)
+
+
+def dynamic_rescale_l1_base(arr: ScaledArray) -> ScaledArray:
+    """Dynamic rescaling of a ScaledArray, using L1 norm.
+
+    NOTE: by default, computing L1 norm in FP32.
+    """
+    data, scale = get_data_scale(arr)
+    data_sq = jax.lax.abs(data.astype(np.float32))
+    axes = tuple(range(data.ndim))
+    # Get L1 norm + pow2 rounding.
+    norm = jax.lax.reduce_sum_p.bind(data_sq, axes=axes) / data.size
+    norm = pow2_round(norm.astype(scale.dtype))
+    # Rebalancing based on norm.
+    return rebalance(arr, norm)
+
+
+def dynamic_rescale_l2_base(arr: ScaledArray) -> ScaledArray:
+    """Dynamic rescaling of a ScaledArray, using L2 norm.
+
+    NOTE: by default, computing L2 norm in FP32.
+    """
+    data, scale = get_data_scale(arr)
+    data_sq = jax.lax.integer_pow(data.astype(np.float32), 2)
+    axes = tuple(range(data.ndim))
+    # Get L2 norm + pow2 rounding.
+    norm = jax.lax.sqrt(jax.lax.reduce_sum_p.bind(data_sq, axes=axes)) / data.size
+    norm = pow2_round(norm.astype(scale.dtype))
+    # Rebalancing based on norm.
+    return rebalance(arr, norm)
+
+
+# Dynamic rescale on fwd arrays.
+dynamic_rescale_max = partial(fn_with_identity_grad, dynamic_rescale_max_base)
+dynamic_rescale_l1 = partial(fn_with_identity_grad, dynamic_rescale_l1_base)
+dynamic_rescale_l2 = partial(fn_with_identity_grad, dynamic_rescale_l2_base)
+
+# Dynamic rescale on gradients.
+dynamic_rescale_max_grad = partial(fn_on_grad, dynamic_rescale_max_base)
+dynamic_rescale_l1_grad = partial(fn_on_grad, dynamic_rescale_l1_base)
+dynamic_rescale_l2_grad = partial(fn_on_grad, dynamic_rescale_l2_base)

--- a/tests/ops/test_rescaling.py
+++ b/tests/ops/test_rescaling.py
@@ -1,0 +1,38 @@
+# Copyright (c) 2023 Graphcore Ltd. All rights reserved.
+import chex
+import numpy as np
+import numpy.testing as npt
+
+from jax_scaled_arithmetics.core import ScaledArray, scaled_array
+from jax_scaled_arithmetics.ops import dynamic_rescale_l1, dynamic_rescale_l2, dynamic_rescale_max
+
+
+class DynamicRescaleOpsTests(chex.TestCase):
+    def test__dynamic_rescale_max__proper_max_rescale_pow2_rounding(self):
+        arr_in = scaled_array([2, -3], np.float16(4), dtype=np.float16)
+        arr_out = dynamic_rescale_max(arr_in)
+
+        assert isinstance(arr_out, ScaledArray)
+        assert arr_out.dtype == arr_in.dtype
+        npt.assert_array_equal(arr_out.scale, np.float16(8))
+        npt.assert_array_equal(arr_out, arr_in)
+
+    def test__dynamic_rescale_l1__proper_l1_rescale_pow2_rounding(self):
+        # L1 norm = 2
+        arr_in = scaled_array([1, -6], np.float16(4), dtype=np.float16)
+        arr_out = dynamic_rescale_l1(arr_in)
+
+        assert isinstance(arr_out, ScaledArray)
+        assert arr_out.dtype == arr_in.dtype
+        npt.assert_array_equal(arr_out.scale, np.float16(8))
+        npt.assert_array_equal(arr_out, arr_in)
+
+    def test__dynamic_rescale_l2__proper_max_rescale_pow2_rounding(self):
+        # L2 norm = 8.945
+        arr_in = scaled_array([4, -8], np.float16(4), dtype=np.float16)
+        arr_out = dynamic_rescale_l2(arr_in)
+
+        assert isinstance(arr_out, ScaledArray)
+        assert arr_out.dtype == arr_in.dtype
+        npt.assert_array_equal(arr_out.scale, np.float16(16))
+        npt.assert_array_equal(arr_out, arr_in)


### PR DESCRIPTION
Methods `dynamic_rescale_max`, `dynamic_rescale_l1` and `dynamic_rescale_l2`
will adapt the scale based on the max/l1/l2 norms of the `data` component.

Equivalent methods are available on the backward pass (`xxx_grad` functions).

In normal/unscaled JAX mode, these functions are no-ops.