### PR TITLE
Improve robustness of scaled translation with zero scale inputs.

### DIFF
--- a/jax_scaled_arithmetics/core/__init__.py
+++ b/jax_scaled_arithmetics/core/__init__.py
@@ -23,4 +23,4 @@ from .interpreters import (  # noqa: F401
     register_scaled_op,
 )
 from .typing import Array, ArrayTypes, get_numpy_api  # noqa: F401
-from .utils import Pow2RoundMode, pow2_round, pow2_round_down, pow2_round_up  # noqa: F401
+from .utils import Pow2RoundMode, pow2_round, pow2_round_down, pow2_round_up, safe_div, safe_reciprocal  # noqa: F401

--- a/jax_scaled_arithmetics/ops/rescaling.py
+++ b/jax_scaled_arithmetics/ops/rescaling.py
@@ -78,7 +78,7 @@ def dynamic_rescale_l2_base(arr: ScaledArray) -> ScaledArray:
     data_sq = jax.lax.integer_pow(data.astype(np.float32), 2)
     axes = tuple(range(data.ndim))
     # Get L2 norm + pow2 rounding.
-    norm = jax.lax.sqrt(jax.lax.reduce_sum_p.bind(data_sq, axes=axes)) / data.size
+    norm = jax.lax.sqrt(jax.lax.reduce_sum_p.bind(data_sq, axes=axes) / data.size)
     norm = pow2_round(norm.astype(scale.dtype))
     # Rebalancing based on norm.
     return rebalance(arr, norm)

--- a/tests/lax/test_base_scaling_primitives.py
+++ b/tests/lax/test_base_scaling_primitives.py
@@ -32,6 +32,22 @@ class SetScalingPrimitiveTests(chex.TestCase):
         npt.assert_array_equal(output, values)
 
     @chex.variants(with_jit=True, without_jit=True)
+    @parameterized.parameters(
+        {"arr": np.array([-1.0, 2.0], dtype=np.float32)},
+        {"arr": scaled_array([-1.0, 2.0], 1.0, dtype=np.float16)},
+        {"arr": scaled_array([-1.0, 2.0], 0.0, dtype=np.float32)},
+    )
+    def test__set_scaling_primitive__zero_scaling(self, arr):
+        def fn(arr, scale):
+            return set_scaling(arr, scale)
+
+        scale = np.array(0, dtype=arr.dtype)
+        out = self.variant(autoscale(fn))(arr, scale)
+        assert isinstance(out, ScaledArray)
+        npt.assert_array_almost_equal(out.scale, 0)
+        npt.assert_array_almost_equal(out.data, 0)
+
+    @chex.variants(with_jit=True, without_jit=True)
     def test__set_scaling_primitive__proper_result_without_autoscale(self):
         def fn(arr, scale):
             return set_scaling(arr, scale)

--- a/tests/lax/test_scaled_ops_common.py
+++ b/tests/lax/test_scaled_ops_common.py
@@ -81,6 +81,15 @@ class ScaledTranslationPrimitivesTests(chex.TestCase):
         npt.assert_array_equal(z.scale, y.scale)
         npt.assert_array_almost_equal(z, lax.concatenate([np.asarray(x), np.asarray(y)], dimension=0))
 
+    def test__scaled_concatenate__zero_input_scales(self):
+        x = scaled_array(self.rs.rand(2, 3), 0.0, dtype=np.float16)
+        y = scaled_array(self.rs.rand(5, 3), 0.0, dtype=np.float16)
+        z = scaled_concatenate([x, y], dimension=0)
+        assert isinstance(z, ScaledArray)
+        assert z.dtype == x.dtype
+        npt.assert_array_equal(z.scale, 0)
+        npt.assert_array_almost_equal(z, lax.concatenate([np.asarray(x), np.asarray(y)], dimension=0))
+
     def test__scaled_convert_element_type__proper_scaling(self):
         x = scaled_array(self.rs.rand(5), 2, dtype=np.float32)
         z = scaled_convert_element_type(x, new_dtype=np.float16)


### PR DESCRIPTION
Adding `safe_div` and `safe_reciprocal` in order to avoid generating `inf` and `nan` when input scales are zero.