### PR TITLE
Add a default scale dtype to AutoScaleConfig

### DIFF
--- a/jax_scaled_arithmetics/core/interpreters.py
+++ b/jax_scaled_arithmetics/core/interpreters.py
@@ -15,7 +15,7 @@ from jax._src.custom_derivatives import (
 )
 from jax._src.util import safe_map
 
-from .datatype import NDArray, ScaledArray, as_scaled_array_base, is_scaled_leaf
+from .datatype import DTypeLike, NDArray, ScaledArray, as_scaled_array_base, is_scaled_leaf
 from .utils import Pow2RoundMode
 
 
@@ -25,9 +25,14 @@ class AutoScaleConfig:
 
     NOTE: this config can be locally changed using a Python context manager:
     `with AutoScaleConfig(...):`
+
+    Args:
+        rounding_mode: Power-of-2 rounding mode.
+        scale_dtype: Scale (default) datatype.
     """
 
     rounding_mode: Pow2RoundMode = Pow2RoundMode.DOWN
+    scale_dtype: DTypeLike = None
 
     def __enter__(self):
         global _autoscale_config_stack

--- a/tests/core/test_interpreter.py
+++ b/tests/core/test_interpreter.py
@@ -237,9 +237,11 @@ class AutoScaleInterpreterTests(chex.TestCase):
         cfg = get_autoscale_config()
         assert isinstance(cfg, AutoScaleConfig)
         assert cfg.rounding_mode == Pow2RoundMode.DOWN
+        assert cfg.scale_dtype is None
 
     def test__autoscale_config__context_manager(self):
-        with AutoScaleConfig(rounding_mode=Pow2RoundMode.NONE):
+        with AutoScaleConfig(rounding_mode=Pow2RoundMode.NONE, scale_dtype=np.float32):
             cfg = get_autoscale_config()
             assert isinstance(cfg, AutoScaleConfig)
             assert cfg.rounding_mode == Pow2RoundMode.NONE
+            assert cfg.scale_dtype == np.float32

--- a/tests/lax/test_base_scaling_primitives.py
+++ b/tests/lax/test_base_scaling_primitives.py
@@ -5,7 +5,7 @@ import numpy as np
 import numpy.testing as npt
 from absl.testing import parameterized
 
-from jax_scaled_arithmetics.core import Array, ScaledArray, autoscale, scaled_array
+from jax_scaled_arithmetics.core import Array, AutoScaleConfig, ScaledArray, autoscale, scaled_array
 from jax_scaled_arithmetics.lax.base_scaling_primitives import (
     get_data_scale,
     rebalance,
@@ -146,13 +146,17 @@ class GetDataScalePrimitiveTests(chex.TestCase):
     @chex.variants(with_jit=True, without_jit=True)
     def test__get_data_scale_primitive__proper_result_without_autoscale(self):
         def fn(arr):
-            return get_data_scale(arr)
+            # Set a default scale dtype.
+            with AutoScaleConfig(scale_dtype=np.float32):
+                return get_data_scale(arr)
 
         fn = self.variant(fn)
         arr = jnp.array([2, 3], dtype=np.float16)
         data, scale = fn(arr)
+        assert data.dtype == np.float16
+        assert scale.dtype == np.float32
         npt.assert_array_equal(data, arr)
-        npt.assert_equal(scale, np.array(1, arr.dtype))
+        npt.assert_equal(scale, np.array(1, np.float32))
 
     @chex.variants(with_jit=True, without_jit=True)
     def test__get_data_scale_primitive__proper_result_with_autoscale(self):


### PR DESCRIPTION
The default scale dtype can be set with `AutoScaleConfig(scale_dtype=xxx)` context manager. Having a default scale dtype information when the dtype of `data` and `scale` are not the same. If no information is provided, the `autoscale` JAX interpreter has no way of deciding which dtype is the proper one during the initial tracing.