### PR TITLE
Use `float32` scale in AutoScale MNIST training example.

### DIFF
--- a/jax_scaled_arithmetics/core/datatype.py
+++ b/jax_scaled_arithmetics/core/datatype.py
@@ -94,6 +94,12 @@ class ScaledArray:
         """Abstract value of the scaled array, i.e. shape and dtype."""
         return ShapedArray(self.data.shape, self.data.dtype)
 
+    def astype(self, dtype) -> "ScaledArray":
+        """Convert the ScaledArray to a dtype.
+        NOTE: only impacting `data` field, not the `scale` tensor.
+        """
+        return ScaledArray(self.data.astype(dtype), self.scale)
+
 
 def make_scaled_scalar(val: Array) -> ScaledArray:
     """Make a scaled scalar (array), from a single value.

--- a/jax_scaled_arithmetics/lax/base_scaling_primitives.py
+++ b/jax_scaled_arithmetics/lax/base_scaling_primitives.py
@@ -189,7 +189,6 @@ def get_data_scale_abstract_eval(values: core.ShapedArray) -> core.ShapedArray:
         return (values.data, values.scale)
     # Use array dtype for scale by default.
     scale_dtype = get_scale_dtype() or values.dtype
-    print(scale_dtype)
     return values, core.ShapedArray((), dtype=scale_dtype)
 
 

--- a/tests/core/test_datatype.py
+++ b/tests/core/test_datatype.py
@@ -104,6 +104,16 @@ class ScaledArrayDataclassTests(chex.TestCase):
         npt.assert_array_equal(out, sarr.data * sarr.scale)
 
     @parameterized.parameters(
+        {"npapi": np},
+        {"npapi": jnp},
+    )
+    def test__scaled_array__astype(self, npapi):
+        arr_in = ScaledArray(data=npapi.array([1.0, 2.0], dtype=np.float16), scale=npapi.array(1, dtype=np.int32))
+        arr_out = arr_in.astype(np.float32)
+        assert arr_out.dtype == np.float32
+        assert arr_out.scale.dtype == arr_in.scale.dtype
+
+    @parameterized.parameters(
         {"val": 0.25},
     )
     def test__make_scaled_scalar__float_input(self, val):


### PR DESCRIPTION
In some configurations, `float16` does not have enough dynamic range to represent scaling, meaning the scale factor can quickly overflow. Using `float32` (or equivalently `bfloat16`) should allow a bit more margin.