### PR TITLE
Improving robustness of `log` and `exp`, with proper special values o…

### DIFF
--- a/tests/lax/test_scipy_integration.py
+++ b/tests/lax/test_scipy_integration.py
@@ -3,15 +3,24 @@ import chex
 import numpy as np
 import numpy.testing as npt
 from absl.testing import parameterized
+from jax import lax
 
 from jax_scaled_arithmetics.core import autoscale, scaled_array
 
 
-class ScaledTranslationPrimitivesTests(chex.TestCase):
+class ScaledScipyHighLevelMethodsTests(chex.TestCase):
     def setUp(self):
         super().setUp()
         # Use random state for reproducibility!
         self.rs = np.random.RandomState(42)
+
+    def test__lax_full_like__zero_scale(self):
+        def fn(a):
+            return lax.full_like(a, 0)
+
+        a = scaled_array(np.random.rand(3, 5).astype(np.float32), np.float32(1))
+        autoscale(fn)(a)
+        # FIMXE/TODO: what should be the expected result?
 
     @parameterized.parameters(
         {"dtype": np.float32},


### PR DESCRIPTION
…utput.

Making sure that `exp` of `0` is `1` and `log` of `0` is `-inf`. Using a custom `logsumexp` in MNIST example until an additional scale propagation bug is solved.

NOTE: additional robustness means MNIST training converges when initialization scale > 1.