### PR TITLE
Implement AutoScale/Scalify TracerMetaArray data structure.

### DIFF
--- a/jax_scaled_arithmetics/core/utils.py
+++ b/jax_scaled_arithmetics/core/utils.py
@@ -102,3 +102,19 @@ def safe_reciprocal(val: Array) -> Array:
         return np.reciprocal(val, out=np.array(0, dtype=val.dtype), where=val != 0)
     # JAX general implementation.
     return jax.lax.select(val == 0, val, jax.lax.reciprocal(val))
+
+
+def python_scalar_as_numpy(val: Any) -> Any:
+    """Convert Python scalar to Numpy scalar, if possible.
+
+    Using by default JAX 32 bits precision, instead of 64 bits.
+
+    Returning unchanged value if not any (bool, int, float).
+    """
+    if isinstance(val, bool):
+        return np.bool_(val)
+    elif isinstance(val, int):
+        return np.int32(val)
+    elif isinstance(val, float):
+        return np.float32(val)
+    return val

--- a/tests/core/test_utils.py
+++ b/tests/core/test_utils.py
@@ -6,7 +6,13 @@ import numpy.testing as npt
 from absl.testing import parameterized
 
 from jax_scaled_arithmetics.core import Array, pow2_round_down, pow2_round_up
-from jax_scaled_arithmetics.core.utils import _exponent_bits_mask, get_mantissa, safe_div, safe_reciprocal
+from jax_scaled_arithmetics.core.utils import (
+    _exponent_bits_mask,
+    get_mantissa,
+    python_scalar_as_numpy,
+    safe_div,
+    safe_reciprocal,
+)
 
 
 class Pow2RoundingUtilTests(chex.TestCase):
@@ -90,3 +96,9 @@ class SafeDivOpTests(chex.TestCase):
         out = safe_reciprocal(val)
         assert out.dtype == val.dtype
         npt.assert_almost_equal(out, 0)
+
+
+def test__python_scalar_as_numpy__proper_convertion():
+    npt.assert_equal(python_scalar_as_numpy(False), np.bool_(False))
+    npt.assert_equal(python_scalar_as_numpy(4), np.int32(4))
+    npt.assert_equal(python_scalar_as_numpy(3.2), np.float32(3.2))


### PR DESCRIPTION
Introducing the dataclass `ScalifyTracerArray` in JSA interpreter/tracer in order to be able to pass additional metadata on the array (e.g. whether it is a broadcasted scalar tensor).