### PR TITLE
Forwarding broadcasted scalar metadata in Scalify tracer.

### DIFF
--- a/jax_scaled_arithmetics/core/datatype.py
+++ b/jax_scaled_arithmetics/core/datatype.py
@@ -171,6 +171,7 @@ def as_scaled_array_base(
     if isinstance(val, ScaledArray):
         return val
 
+    assert scale is None or scale_dtype is None
     # Simple case => when can ignore the scaling factor (i.e. 1 implicitely).
     is_static_one_scale: bool = scale is None or is_static_one_scalar(scale)  # type:ignore
     # Trivial cases: bool, int, float.
@@ -189,12 +190,15 @@ def as_scaled_array_base(
 
     scale_dtype = scale_dtype or val.dtype
     scale = np.array(1, dtype=scale_dtype) if scale is None else scale
-    if isinstance(val, (np.ndarray, Array)):
+    if isinstance(val, (np.ndarray, *ArrayTypes)):
         if is_static_one_scale:
             return ScaledArray(val, scale)
         else:
             return ScaledArray(val / scale.astype(val.dtype), scale)  # type:ignore
-    return scaled_array_base(val, scale)
+
+    # TODO: fix bug when scale is not 1.
+    raise NotImplementedError(f"Constructing `ScaledArray` from {val} and {scale} not supported.")
+    # return scaled_array_base(val, scale)
 
 
 def as_scaled_array(val: Any, scale: Optional[ArrayLike] = None) -> ScaledArray:

--- a/jax_scaled_arithmetics/lax/scaled_ops_common.py
+++ b/jax_scaled_arithmetics/lax/scaled_ops_common.py
@@ -153,7 +153,7 @@ def scaled_mul(lhs: ScaledArray, rhs: ScaledArray) -> ScaledArray:
 @core.register_scaled_lax_op
 def scaled_div(lhs: ScaledArray, rhs: ScaledArray) -> ScaledArray:
     # TODO: understand when promotion is really required?
-    lhs, rhs = as_scaled_array((lhs, rhs))  # type:ignore
+    # lhs, rhs = as_scaled_array((lhs, rhs))  # type:ignore
     # TODO: investigate different rule?
     return ScaledArray(lhs.data / rhs.data, lhs.scale / rhs.scale)
 

--- a/jax_scaled_arithmetics/lax/scaled_ops_l2.py
+++ b/jax_scaled_arithmetics/lax/scaled_ops_l2.py
@@ -10,7 +10,6 @@ from jax_scaled_arithmetics import core
 from jax_scaled_arithmetics.core import (
     DTypeLike,
     ScaledArray,
-    as_scaled_array,
     get_autoscale_config,
     pow2_round,
     register_scaled_op,
@@ -23,7 +22,7 @@ from .scaled_ops_common import check_scalar_scales, promote_scale_types
 def scaled_add_sub(A: ScaledArray, B: ScaledArray, binary_op: Any) -> ScaledArray:
     """Scaled add/sub generic implementation."""
     # TODO: understand when promotion is really required?
-    A, B = as_scaled_array((A, B))  # type:ignore
+    # A, B = as_scaled_array((A, B))  # type:ignore
     check_scalar_scales(A, B)
     A, B = promote_scale_types(A, B)
     assert np.issubdtype(A.scale.dtype, np.floating)

--- a/tests/lax/test_numpy_integration.py
+++ b/tests/lax/test_numpy_integration.py
@@ -1,0 +1,32 @@
+# Copyright (c) 2023 Graphcore Ltd. All rights reserved.
+import chex
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from jax_scaled_arithmetics.core import ScaledArray, autoscale, scaled_array
+
+
+class ScaledJaxNumpyFunctions(chex.TestCase):
+    def setUp(self):
+        super().setUp()
+        # Use random state for reproducibility!
+        self.rs = np.random.RandomState(42)
+
+    @chex.variants(with_jit=True, without_jit=True)
+    def test__numpy_mean__proper_gradient_scale_propagation(self):
+        def mean_fn(x):
+            # Taking the square to "force" ScaledArray gradient.
+            # Numpy mean constant rescaling creating trouble on backward pass!
+            return jax.grad(lambda v: jnp.mean(v * v))(x)
+
+        # size = 8 * 16
+        input_scaled = scaled_array(self.rs.rand(8, 16).astype(np.float32), np.float32(1))
+        output_grad_scaled = self.variant(autoscale(mean_fn))(input_scaled)
+
+        assert isinstance(output_grad_scaled, ScaledArray)
+        # Proper scale propagation on the backward pass (rough interval)
+        assert np.std(output_grad_scaled.data) >= 0.25
+        assert np.std(output_grad_scaled.data) <= 1.0
+        # "small" scale.
+        assert output_grad_scaled.scale <= 0.01


### PR DESCRIPTION
`scalify` interpreter/tracer is now properly tracking which tensors are
just broadcasted scalars, helping then to refine the conversion rule to
ScaledArray for these.

In practice: it means (finally!) proper full scale propagation in MNIST training,
resulting in stable training with dynamic rescale.

TODO: we still need to understand why `scaled_mul` requires ScaledArray promotion to
get the MNIST training example running. This requirement has been lifted in `div/add/sub`
thanks to this PR.