### PR TITLE
Getting MNIST training working properly with `jax.nn.relu`

### DIFF
--- a/jax_scaled_arithmetics/core/datatype.py
+++ b/jax_scaled_arithmetics/core/datatype.py
@@ -43,6 +43,9 @@ class ScaledArray:
     scale: GenericArray
 
     def __post_init__(self):
+        # Always have a Numpy array as `data`.
+        if isinstance(self.data, np.number):
+            object.__setattr__(self, "data", np.array(self.data))
         # TODO/FIXME: support number as data?
         assert isinstance(self.data, (*ArrayTypes, np.ndarray))
         assert isinstance(self.scale, (*ArrayTypes, np.ndarray, np.number))

--- a/tests/lax/test_scipy_integration.py
+++ b/tests/lax/test_scipy_integration.py
@@ -29,9 +29,11 @@ class ScaledScipyHighLevelMethodsTests(chex.TestCase):
     def test__scipy_logsumexp__accurate_scaled_op(self, dtype):
         from jax.scipy.special import logsumexp
 
-        input_scaled = scaled_array(self.rs.rand(10), 2, dtype=dtype)
+        input_scaled = scaled_array(self.rs.rand(10), 4.0, dtype=dtype)
         # JAX `logsumexp` Jaxpr is a non-trivial graph!
         out_scaled = autoscale(logsumexp)(input_scaled)
         out_expected = logsumexp(np.asarray(input_scaled))
         assert out_scaled.dtype == out_expected.dtype
+        # Proper accuracy + keep the same scale.
+        npt.assert_array_equal(out_scaled.scale, input_scaled.scale)
         npt.assert_array_almost_equal(out_scaled, out_expected, decimal=5)


### PR DESCRIPTION
This PR is fixing backward propagation of in `jax.nn.relu`, properly handling `lax.select` adn `lax.full_like` scale propagation. As a consequence, JAX scipy `logsumexp` scale propagation is now working properly.