### PR TITLE
Implement JAX `pow2_decompose` primitive.

### DIFF
--- a/experiments/mnist/mnist_classifier_from_scratch.py
+++ b/experiments/mnist/mnist_classifier_from_scratch.py
@@ -66,7 +66,7 @@ def predict(params, inputs):
 def loss(params, batch):
     inputs, targets = batch
     preds = predict(params, inputs)
-    targets = jsa.lax.rebalance(targets, np.float32(1 / 16))
+    targets = jsa.lax.rebalance(targets, np.float32(1 / 8))
     return -jnp.mean(jnp.sum(preds * targets, axis=1))
 
 

--- a/jax_scaled_arithmetics/core/__init__.py
+++ b/jax_scaled_arithmetics/core/__init__.py
@@ -22,5 +22,6 @@ from .interpreters import (  # noqa: F401
     register_scaled_lax_op,
     register_scaled_op,
 )
+from .pow2 import Pow2RoundMode, pow2_decompose, pow2_round, pow2_round_down, pow2_round_up  # noqa: F401
 from .typing import Array, ArrayTypes, get_numpy_api  # noqa: F401
-from .utils import Pow2RoundMode, pow2_round, pow2_round_down, pow2_round_up, safe_div, safe_reciprocal  # noqa: F401
+from .utils import safe_div, safe_reciprocal  # noqa: F401

--- a/jax_scaled_arithmetics/core/interpreters.py
+++ b/jax_scaled_arithmetics/core/interpreters.py
@@ -26,7 +26,8 @@ from .datatype import (
     is_scaled_leaf,
     is_static_zero,
 )
-from .utils import Pow2RoundMode, python_scalar_as_numpy
+from .pow2 import Pow2RoundMode
+from .utils import python_scalar_as_numpy
 
 
 @dataclass(frozen=True)

--- a/jax_scaled_arithmetics/core/pow2.py
+++ b/jax_scaled_arithmetics/core/pow2.py
@@ -1,0 +1,163 @@
+# Copyright (c) 2023 Graphcore Ltd. All rights reserved.
+import logging
+from enum import IntEnum
+from functools import partial
+from typing import Any, Dict, Optional, Sequence, Tuple, Union
+
+import numpy as np
+from jax import core
+from jax.interpreters import mlir
+from jax.interpreters.mlir import LoweringRuleContext, ir
+from numpy.typing import DTypeLike, NDArray
+
+from .typing import Array, get_numpy_api
+
+# Exponent bits masking.
+_exponent_bits_mask: Dict[Any, NDArray[Any]] = {
+    np.dtype(np.float16): np.packbits(np.array([0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 0, 0], dtype=np.uint8)).view(
+        np.int16
+    ),
+    np.dtype(np.float32): np.packbits(
+        np.array(
+            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1],
+            dtype=np.uint8,
+        )
+    ).view(np.int32),
+    np.dtype(np.float64): np.array(np.inf, np.float64).view(np.int64),
+}
+"""Exponents bit masking: explicit bitmask to keep only exponent bits in floating point values.
+
+NOTE: normally should also correspond to `np.inf` value for FP16 and FP32.
+"""
+
+
+def pow2_decompose_round_down_impl(vin: Array, scale_dtype: DTypeLike) -> Array:
+    """Pow-2 decompose with rounding down.
+
+    Returns:
+        (scale, vout) such that vin = scale * vout
+    """
+    np_api = get_numpy_api(vin)
+    # Perform all computations in FP32, to support FP16 submormals.
+    # NOTE: `jnp.frexp` is buggy for subnormals.
+    dtype = np.dtype(np.float32)
+    minval = np.finfo(dtype).smallest_normal
+    exponent_mask = _exponent_bits_mask[dtype]
+    intdtype = exponent_mask.dtype
+    val = vin.astype(dtype)
+    # Masking mantissa bits, keeping only the exponents ones.
+    scale_pow2 = np_api.bitwise_and(val.view(intdtype), exponent_mask).view(val.dtype).reshape(val.shape)
+    # Get the mantissa in float32. Make sure we don't divide by zero, and handle nan/inf.
+    normal_scale_val = np_api.logical_and(np_api.isfinite(scale_pow2), scale_pow2 != 0)
+    scale_renorm = np_api.where(normal_scale_val, scale_pow2, minval)
+    mantissa = val / scale_renorm
+    return scale_pow2.astype(scale_dtype), mantissa.astype(vin.dtype)
+
+
+class Pow2RoundMode(IntEnum):
+    """Power-of-two supported rounded mode."""
+
+    NONE = 0
+    DOWN = 1
+    UP = 2
+    STOCHASTIC = 3
+
+
+pow2_decompose_p = core.Primitive("pow2_decompose")
+"""`pow2_decompose` pow2 decompose JAX primitive.
+"""
+
+
+def pow2_decompose(
+    vin: Array, scale_dtype: Optional[DTypeLike] = None, mode: Pow2RoundMode = Pow2RoundMode.DOWN
+) -> Tuple[Array, Array]:
+    """Power-2 decompose, i.e. vin = s * vout where s is a power-of 2 scaling.
+
+    Args:
+        vin: Input array.
+        scale_dtype: Scale dtype to use.
+        mode: Pow2 rounding.
+    Returns:
+        (scale, vout) such that vin = scale * vout
+    """
+    scale_dtype = np.dtype(scale_dtype or vin.dtype)
+    # A couple of checks on dtypes.
+    assert np.issubdtype(vin.dtype, np.floating)
+    assert np.issubdtype(scale_dtype, np.floating)
+    if scale_dtype == np.float16:
+        logging.warning("`pow2_decompose` does not support FP16 sub-normals when using FP16 scale dtype.")
+    out = pow2_decompose_p.bind(vin, scale_dtype=scale_dtype, mode=mode)
+    return out
+
+
+def pow2_decompose_eager_impl(
+    vin: Array, scale_dtype: Optional[DTypeLike] = None, mode: Pow2RoundMode = Pow2RoundMode.DOWN
+) -> Tuple[Array, Array]:
+    """Eager mode implementation, on JAX/Numpy arrays."""
+    if mode == Pow2RoundMode.DOWN:
+        return pow2_decompose_round_down_impl(vin, scale_dtype)
+    raise NotImplementedError(f"Unsupported power-of-2 rounding mode '{mode}'.")
+
+
+def pow2_decompose_abstract_eval(
+    vin: core.ShapedArray, scale_dtype: Optional[DTypeLike] = None, mode: Pow2RoundMode = Pow2RoundMode.DOWN
+) -> Tuple[core.ShapedArray, core.ShapedArray]:
+    scale_dtype = scale_dtype or vin.dtype
+    sout = core.ShapedArray(vin.shape, dtype=scale_dtype)
+    return (sout, vin)
+
+
+def pow2_decompose_mlir_lowering(
+    ctx: LoweringRuleContext, *args: Union[ir.Value, Sequence[ir.Value]], **params
+) -> Sequence[Union[ir.Value, Sequence[ir.Value]]]:
+    scale_dtype = params["scale_dtype"]
+    mode = params["mode"]
+    pow2_decompose_fn = partial(pow2_decompose_eager_impl, scale_dtype=scale_dtype, mode=mode)
+    outputs = mlir.lower_fun(pow2_decompose_fn, multiple_results=True)(ctx, *args)
+    return outputs
+
+
+# Register as standard JAX primitive
+pow2_decompose_p.multiple_results = True
+pow2_decompose_p.def_abstract_eval(pow2_decompose_abstract_eval)
+pow2_decompose_p.def_impl(pow2_decompose_eager_impl)
+# Default lowering on GPU, TPU, ...
+mlir.register_lowering(pow2_decompose_p, pow2_decompose_mlir_lowering)
+
+
+def pow2_round_down(val: Array) -> Array:
+    """Round down to the closest power of 2."""
+    # Keep only the scale component of `pow2_decompose`
+    pow2_val, _ = pow2_decompose(val, scale_dtype=val.dtype, mode=Pow2RoundMode.DOWN)
+    return pow2_val
+
+
+def pow2_round_up(val: Array) -> Array:
+    """Round up to the closest power of 2.
+    NOTE: may overflow to inf.
+    """
+    # FIXME: rounding when already a power of 2.
+    # Should do additional masking to check that.
+    pow2_val = pow2_round_down(val) * np.array(2, dtype=val.dtype)
+    return pow2_val
+
+
+def pow2_round(val: Array, mode: Pow2RoundMode = Pow2RoundMode.DOWN) -> Array:
+    """Power-of-two rounding."""
+    if mode == Pow2RoundMode.NONE:
+        return val
+    elif mode == Pow2RoundMode.DOWN:
+        return pow2_round_down(val)
+    elif mode == Pow2RoundMode.UP:
+        return pow2_round_up(val)
+    raise NotImplementedError(f"Unsupported power-of-2 rounding mode '{mode}'.")
+
+
+def get_mantissa(val: Array) -> Array:
+    """Extract the mantissa of an array, masking the exponent.
+
+    Similar to `numpy.frexp`, but with implicit bit to be consistent with
+    `pow2_round_down`.
+    """
+    _, mantissa = pow2_decompose(val, scale_dtype=val.dtype, mode=Pow2RoundMode.DOWN)
+    return mantissa

--- a/jax_scaled_arithmetics/core/utils.py
+++ b/jax_scaled_arithmetics/core/utils.py
@@ -1,84 +1,11 @@
 # Copyright (c) 2023 Graphcore Ltd. All rights reserved.
-from enum import IntEnum
-from typing import Any, Dict
+from typing import Any
 
 import jax
 import jax.numpy as jnp
 import numpy as np
-from numpy.typing import NDArray
 
-from .typing import Array, get_numpy_api
-
-# Exponent bits masking.
-_exponent_bits_mask: Dict[Any, NDArray[Any]] = {
-    np.dtype(np.float16): np.packbits(np.array([0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 0, 0], dtype=np.uint8)).view(
-        np.int16
-    ),
-    np.dtype(np.float32): np.packbits(
-        np.array(
-            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1],
-            dtype=np.uint8,
-        )
-    ).view(np.int32),
-    np.dtype(np.float64): np.array(np.inf, np.float64).view(np.int64),
-}
-"""Exponents bit masking: explicit bitmask to keep only exponent bits in floating point values.
-
-NOTE: normally should also correspond to `np.inf` value for FP16 and FP32.
-"""
-
-
-class Pow2RoundMode(IntEnum):
-    """Power-of-two supported rounded mode."""
-
-    NONE = 0
-    DOWN = 1
-    UP = 2
-    STOCHASTIC = 3
-
-
-def get_mantissa(val: Array) -> Array:
-    """Extract the mantissa of an array, masking the exponent.
-
-    Similar to `numpy.frexp`, but with implicit bit to be consistent with
-    `pow2_round_down`.
-    """
-    np_api = get_numpy_api(val)
-    # TODO: implement using bitmasking?
-    mantissa_val, _ = np_api.frexp(val)
-    # Re-add the implicit bit to be consistent with `pow2_round_down`
-    mantissa_val = mantissa_val * np.array(2, dtype=val.dtype)
-    return mantissa_val
-
-
-def pow2_round_down(val: Array) -> Array:
-    """Round down to the closest power of 2."""
-    np_api = get_numpy_api(val)
-    exponent_mask = _exponent_bits_mask[val.dtype]
-    intdtype = exponent_mask.dtype
-    pow2_val = np_api.bitwise_and(val.view(intdtype), exponent_mask).view(val.dtype).reshape(val.shape)
-    return pow2_val
-
-
-def pow2_round_up(val: Array) -> Array:
-    """Round up to the closest power of 2.
-    NOTE: may overflow to inf.
-    """
-    # FIXME: rounding when already a power of 2.
-    # Should do additional masking to check that.
-    pow2_val = pow2_round_down(val) * np.array(2, dtype=val.dtype)
-    return pow2_val
-
-
-def pow2_round(val: Array, mode: Pow2RoundMode = Pow2RoundMode.DOWN) -> Array:
-    """Power-of-two rounding."""
-    if mode == Pow2RoundMode.NONE:
-        return val
-    elif mode == Pow2RoundMode.DOWN:
-        return pow2_round_down(val)
-    elif mode == Pow2RoundMode.UP:
-        return pow2_round_up(val)
-    raise NotImplementedError(f"Unsupported power-of-2 rounding mode '{mode}'.")
+from .typing import Array
 
 
 def safe_div(lhs: Array, rhs: Array) -> Array:

--- a/jax_scaled_arithmetics/lax/scaled_ops_common.py
+++ b/jax_scaled_arithmetics/lax/scaled_ops_common.py
@@ -165,6 +165,13 @@ def scaled_div(lhs: ScaledArray, rhs: ScaledArray) -> ScaledArray:
 
 
 @core.register_scaled_lax_op
+def scaled_sign(val: ScaledArray) -> Array:
+    assert isinstance(val, ScaledArray)
+    # Just need to run `lax.sign` on main data.
+    return ScaledArray(lax.sign(val.data), np.array(1, dtype=val.scale.dtype))
+
+
+@core.register_scaled_lax_op
 def scaled_is_finite(val: ScaledArray) -> Array:
     assert isinstance(val, ScaledArray)
     if np.issubdtype(val.scale.dtype, np.integer):

--- a/tests/core/test_pow2.py
+++ b/tests/core/test_pow2.py
@@ -1,0 +1,138 @@
+# Copyright (c) 2023 Graphcore Ltd. All rights reserved.
+from functools import partial
+
+import chex
+import jax.numpy as jnp
+import numpy as np
+import numpy.testing as npt
+from absl.testing import parameterized
+
+from jax_scaled_arithmetics.core import Pow2RoundMode, pow2_decompose, pow2_round_down, pow2_round_up
+from jax_scaled_arithmetics.core.pow2 import _exponent_bits_mask, get_mantissa
+
+
+class Pow2DecomposePrimitveTests(chex.TestCase):
+    @parameterized.parameters(
+        {"dtype": np.float16},
+        {"dtype": np.float32},
+    )
+    def test__exponent_bitmask__inf_value(self, dtype):
+        val = _exponent_bits_mask[np.dtype(dtype)].view(dtype)
+        expected_val = dtype(np.inf)
+        npt.assert_equal(val, expected_val)
+
+    @parameterized.product(
+        val_exp=[
+            (0, 0),
+            (1, 1),
+            (2.1, 2),
+            (0.3, 0.25),
+            (0.51, 0.5),
+            (65500, 32768),
+            # Test float16 sub-normals.
+            (np.finfo(np.float16).smallest_normal, np.finfo(np.float16).smallest_normal),
+            (np.finfo(np.float16).smallest_subnormal, np.finfo(np.float16).smallest_subnormal),
+            (np.float16(3.123283386230469e-05), 3.0517578e-05),
+        ],
+        dtype=[np.float16, np.float32],
+        scale_dtype=[np.float16, np.float32],
+    )
+    def test__pow2_decompose_round_down__numpy_implementation__proper_result(self, val_exp, dtype, scale_dtype):
+        scale_dtype = np.float32
+        vin, exp_scale = dtype(val_exp[0]), scale_dtype(val_exp[1])
+        scale, vout = pow2_decompose(vin, scale_dtype, Pow2RoundMode.DOWN)
+
+        assert isinstance(scale, (np.ndarray, np.number))
+        assert isinstance(vout, (np.ndarray, np.number))
+        assert scale.dtype == scale_dtype
+        assert vout.dtype == vin.dtype
+        # Always accurate when casting up to scale dtype.
+        npt.assert_equal(scale * vout.astype(scale_dtype), vin.astype(scale_dtype))
+        npt.assert_equal(scale, exp_scale)
+
+    @chex.variants(with_jit=True, without_jit=True)
+    @parameterized.product(
+        val_exp=[
+            (0, 0),
+            (1, 1),
+            (2.1, 2),
+            (0.3, 0.25),
+            (0.51, 0.5),
+            (65500, 32768),
+            # Test float16 sub-normals.
+            (np.finfo(np.float16).smallest_normal, np.finfo(np.float16).smallest_normal),
+            (np.finfo(np.float16).smallest_subnormal, np.finfo(np.float16).smallest_subnormal),
+            (np.float16(3.123283386230469e-05), 3.0517578e-05),
+            # Test float32 sub-normals: known bug!
+            # (np.finfo(np.float32).smallest_normal, np.finfo(np.float32).smallest_normal),
+            # (np.finfo(np.float32).smallest_subnormal, np.finfo(np.float32).smallest_subnormal),
+        ],
+        dtype=[np.float16, np.float32],
+        scale_dtype=[np.float16, np.float32],
+    )
+    def test__pow2_decompose_round_down__jax_numpy__proper_result(self, val_exp, dtype, scale_dtype):
+        vin, exp_scale = dtype(val_exp[0]), scale_dtype(val_exp[1])
+        vin = jnp.array(vin)
+        scale, vout = self.variant(lambda v: pow2_decompose(v, scale_dtype, Pow2RoundMode.DOWN))(vin)
+
+        assert isinstance(scale, jnp.ndarray)
+        assert isinstance(vout, jnp.ndarray)
+        assert scale.dtype == scale_dtype
+        assert vout.dtype == vin.dtype
+        # Always accurate when casting up to scale dtype.
+        npt.assert_equal(np.asarray(scale), exp_scale)
+        npt.assert_equal(scale * np.array(vout, scale_dtype), np.asarray(vin, scale_dtype))
+
+    @chex.variants(with_jit=True, without_jit=True)
+    @parameterized.product(
+        val_exp=[
+            (+np.inf, np.inf, +np.inf),
+            (-np.inf, np.inf, -np.inf),
+            (np.nan, np.inf, np.nan),  # FIXME? scale == np.inf?
+        ],
+        dtype=[np.float16, np.float32],
+        scale_dtype=[np.float16, np.float32],
+    )
+    def test__pow2_decompose_round_down__special_values(self, val_exp, dtype, scale_dtype):
+        vin, exp_scale, exp_vout = dtype(val_exp[0]), scale_dtype(val_exp[1]), dtype(val_exp[2])
+        scale, vout = self.variant(partial(pow2_decompose, scale_dtype=scale_dtype, mode=Pow2RoundMode.DOWN))(vin)
+        npt.assert_equal(np.ravel(scale)[0], exp_scale)
+        npt.assert_equal(np.ravel(vout)[0], exp_vout)
+
+    @parameterized.product(
+        val_exp=[(0, 0), (1, 1), (2.1, 2), (0.3, 0.25), (0.51, 0.5), (65500, 32768)],
+        dtype=[np.float16, np.float32, np.float64],
+    )
+    def test__pow2_round_down__proper_rounding__multi_dtypes(self, val_exp, dtype):
+        val, exp = dtype(val_exp[0]), dtype(val_exp[1])
+        pow2_val = pow2_round_down(val)
+        assert pow2_val.dtype == val.dtype
+        assert pow2_val.shape == ()
+        assert type(pow2_val) in {type(val), np.ndarray}
+        npt.assert_equal(pow2_val, exp)
+
+    @parameterized.product(
+        val_exp=[(2.1, 4), (0.3, 0.5), (0.51, 1), (17000, 32768)],
+        dtype=[np.float16],
+    )
+    def test__pow2_round_up__proper_rounding__multi_dtypes(self, val_exp, dtype):
+        val, exp = dtype(val_exp[0]), dtype(val_exp[1])
+        pow2_val = pow2_round_up(val)
+        assert pow2_val.dtype == val.dtype
+        assert type(pow2_val) in {type(val), np.ndarray}
+        npt.assert_equal(pow2_val, exp)
+
+    @parameterized.product(
+        val_mant=[(1, 1), (2.1, 1.05), (0, 0), (0.51, 1.02), (65504, 1.9990234375)],
+        dtype=[np.float16, np.float32],  # FIXME: float64 support in pure Numpy
+    )
+    def test__get_mantissa__proper_value__multi_dtypes(self, val_mant, dtype):
+        val, mant = dtype(val_mant[0]), dtype(val_mant[1])
+        val_mant = get_mantissa(val)
+        assert val_mant.dtype == val.dtype
+        assert val_mant.shape == ()
+        assert type(val_mant) in {type(val), np.ndarray}
+        print(mant, val_mant, dtype)
+        npt.assert_equal(val_mant, mant)
+        # Should be consistent with `pow2_round_down`. bitwise, not approximation.
+        npt.assert_equal(mant * pow2_round_down(val), val)

--- a/tests/core/test_utils.py
+++ b/tests/core/test_utils.py
@@ -5,62 +5,7 @@ import numpy as np
 import numpy.testing as npt
 from absl.testing import parameterized
 
-from jax_scaled_arithmetics.core import Array, pow2_round_down, pow2_round_up
-from jax_scaled_arithmetics.core.utils import (
-    _exponent_bits_mask,
-    get_mantissa,
-    python_scalar_as_numpy,
-    safe_div,
-    safe_reciprocal,
-)
-
-
-class Pow2RoundingUtilTests(chex.TestCase):
-    @parameterized.parameters(
-        {"dtype": np.float16},
-        {"dtype": np.float32},
-    )
-    def test__exponent_bitmask__inf_value(self, dtype):
-        val = _exponent_bits_mask[np.dtype(dtype)].view(dtype)
-        expected_val = dtype(np.inf)
-        npt.assert_equal(val, expected_val)
-
-    @parameterized.product(
-        val_mant=[(1, 1), (2.1, 1.05), (0, 0), (0.51, 1.02), (65504, 1.9990234375)],
-        dtype=[np.float16, np.float32, np.float64],
-    )
-    def test__get_mantissa__proper_value__multi_dtypes(self, val_mant, dtype):
-        val, mant = dtype(val_mant[0]), dtype(val_mant[1])
-        val_mant = get_mantissa(val)
-        assert val_mant.dtype == val.dtype
-        assert val_mant.shape == ()
-        assert type(val_mant) in {type(val), np.ndarray}
-        npt.assert_equal(val_mant, mant)
-        # Should be consistent with `pow2_round_down`. bitwise, not approximation.
-        npt.assert_equal(mant * pow2_round_down(val), val)
-
-    @parameterized.product(
-        val_exp=[(0, 0), (1, 1), (2.1, 2), (0.3, 0.25), (0.51, 0.5), (65500, 32768)],
-        dtype=[np.float16, np.float32, np.float64],
-    )
-    def test__pow2_round_down__proper_rounding__multi_dtypes(self, val_exp, dtype):
-        val, exp = dtype(val_exp[0]), dtype(val_exp[1])
-        pow2_val = pow2_round_down(val)
-        assert pow2_val.dtype == val.dtype
-        assert pow2_val.shape == ()
-        assert type(pow2_val) in {type(val), np.ndarray}
-        npt.assert_equal(pow2_val, exp)
-
-    @parameterized.product(
-        val_exp=[(2.1, 4), (0.3, 0.5), (0.51, 1), (17000, 32768)],
-        dtype=[np.float16],
-    )
-    def test__pow2_round_up__proper_rounding__multi_dtypes(self, val_exp, dtype):
-        val, exp = dtype(val_exp[0]), dtype(val_exp[1])
-        pow2_val = pow2_round_up(val)
-        assert pow2_val.dtype == val.dtype
-        assert type(pow2_val) in {type(val), np.ndarray}
-        npt.assert_equal(pow2_val, exp)
+from jax_scaled_arithmetics.core.utils import Array, python_scalar_as_numpy, safe_div, safe_reciprocal
 
 
 class SafeDivOpTests(chex.TestCase):

--- a/tests/lax/test_base_scaling_primitives.py
+++ b/tests/lax/test_base_scaling_primitives.py
@@ -4,6 +4,7 @@ import jax.numpy as jnp
 import numpy as np
 import numpy.testing as npt
 from absl.testing import parameterized
+from numpy.typing import NDArray
 
 from jax_scaled_arithmetics.core import Array, AutoScaleConfig, ScaledArray, autoscale, scaled_array
 from jax_scaled_arithmetics.lax.base_scaling_primitives import (
@@ -95,7 +96,7 @@ class SetScalingPrimitiveTests(chex.TestCase):
         {"scale": np.float32(1)},
     )
     def test__scaled_set_scaling__unchanged_data_scaled_array(self, scale):
-        val = np.array([-1.0, 2.0], dtype=np.float16)
+        val: NDArray[np.float16] = np.array([-1.0, 2.0], dtype=np.float16)
         out = scaled_set_scaling(val, scale)  # type:ignore
         assert isinstance(out, ScaledArray)
         assert out.data is val

--- a/tests/lax/test_numpy_integration.py
+++ b/tests/lax/test_numpy_integration.py
@@ -13,7 +13,7 @@ class ScaledJaxNumpyFunctions(chex.TestCase):
         # Use random state for reproducibility!
         self.rs = np.random.RandomState(42)
 
-    @chex.variants(with_jit=True, without_jit=True)
+    @chex.variants(with_jit=True, without_jit=False)
     def test__numpy_mean__proper_gradient_scale_propagation(self):
         def mean_fn(x):
             # Taking the square to "force" ScaledArray gradient.

--- a/tests/lax/test_scaled_ops_common.py
+++ b/tests/lax/test_scaled_ops_common.py
@@ -23,6 +23,7 @@ from jax_scaled_arithmetics.lax import (
     scaled_reshape,
     scaled_rev,
     scaled_select_n,
+    scaled_sign,
     scaled_slice,
     scaled_transpose,
 )
@@ -103,6 +104,13 @@ class ScaledTranslationPrimitivesTests(chex.TestCase):
         assert isinstance(z, ScaledArray)
         assert z.scale == x.scale
         npt.assert_array_almost_equal(z.data, x.data.T)
+
+    def test__scaled_sign__proper_scaling(self):
+        x = scaled_array(self.rs.rand(3, 5), 2, dtype=np.float32)
+        z = scaled_sign(x)
+        assert isinstance(z, ScaledArray)
+        assert z.scale == 1
+        npt.assert_array_equal(z.data, lax.sign(x.data))
 
     def test__scaled_rev__proper_scaling(self):
         x = scaled_array(self.rs.rand(5), 2, dtype=np.float32)

--- a/tests/lax/test_scipy_integration.py
+++ b/tests/lax/test_scipy_integration.py
@@ -22,6 +22,7 @@ class ScaledScipyHighLevelMethodsTests(chex.TestCase):
         autoscale(fn)(a)
         # FIMXE/TODO: what should be the expected result?
 
+    @chex.variants(with_jit=True, without_jit=True)
     @parameterized.parameters(
         {"dtype": np.float32},
         {"dtype": np.float16},
@@ -31,7 +32,7 @@ class ScaledScipyHighLevelMethodsTests(chex.TestCase):
 
         input_scaled = scaled_array(self.rs.rand(10), 4.0, dtype=dtype)
         # JAX `logsumexp` Jaxpr is a non-trivial graph!
-        out_scaled = autoscale(logsumexp)(input_scaled)
+        out_scaled = self.variant(autoscale(logsumexp))(input_scaled)
         out_expected = logsumexp(np.asarray(input_scaled))
         assert out_scaled.dtype == out_expected.dtype
         # Proper accuracy + keep the same scale.

--- a/tests/ops/test_ml_dtypes.py
+++ b/tests/ops/test_ml_dtypes.py
@@ -6,6 +6,7 @@ import ml_dtypes
 import numpy as np
 import numpy.testing as npt
 from absl.testing import parameterized
+from numpy.typing import NDArray
 
 from jax_scaled_arithmetics.core import autoscale, scaled_array
 from jax_scaled_arithmetics.ops import cast_ml_dtype
@@ -18,7 +19,7 @@ class CastMLDtypeTests(chex.TestCase):
     )
     def test__cast_ml_dtype__consistent_rounding_down(self, ml_dtype):
         # Values potentially "problematic" in FP8.
-        values = np.array([17, -17, 8, 1, 9, 11, 18], np.float16)
+        values: NDArray[np.float16] = np.array([17, -17, 8, 1, 9, 11, 18], np.float16)
         out = cast_ml_dtype(values, dtype=ml_dtype)
         expected_out = values.astype(ml_dtype)
         assert out.dtype == values.dtype
@@ -29,7 +30,7 @@ class CastMLDtypeTests(chex.TestCase):
         {"ml_dtype": ml_dtypes.float8_e5m2},
     )
     def test__cast_ml_dtype__autoscale_compatiblity(self, ml_dtype):
-        values = np.array([17, -17, 8, 1, 9, 11, 18], np.float16)
+        values: NDArray[np.float16] = np.array([17, -17, 8, 1, 9, 11, 18], np.float16)
         arr = scaled_array(values, np.float32(1))
         out = autoscale(partial(cast_ml_dtype, dtype=ml_dtype))(arr)
 


### PR DESCRIPTION
The primitive `pow2_decompose` is the core decomposition kernel used everywhere in AutoScale/Scalify, meaning it is worth properly formalizing it as a JAX primitive, simplifying the Jaxpr level graph and allowing proper custom kernel optimization on different HW platforms (GPU, IPU, TPU, ...).

NOTE: this PR is fixing additional subnormal related bugs, due to inconsistency of `jnp.frexp` vs Numpy.
See: https://github.com/google/jax/issues/19689