### PR TITLE
Using `setuptools-scm` to generate JAX Scalify version.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
+jax_scalify/version.py
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/jax_scalify/__init__.py
+++ b/jax_scalify/__init__.py
@@ -1,6 +1,5 @@
 # Copyright (c) 2023 Graphcore Ltd. All rights reserved.
 from . import core, lax, ops, tree
-from ._version import __version__
 from .core import (  # noqa: F401
     Pow2RoundMode,
     ScaledArray,
@@ -11,3 +10,4 @@ from .core import (  # noqa: F401
     scaled_array,
     scalify,
 )
+from .version import __version__

--- a/jax_scalify/_version.py
+++ b/jax_scalify/_version.py
@@ -1,2 +1,0 @@
-# Copyright (c) 2023 Graphcore Ltd. All rights reserved.
-__version__ = "0.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,6 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "jax_scalify"
-version = "0.1"
 description="JAX Scalify: end-to-end scaled arithmetic."
 readme = "README.md"
 authors = [
@@ -30,6 +29,7 @@ dependencies = [
   "ml_dtypes",
   "numpy >= 1.22.4"
 ]
+dynamic = ["version"]
 
 [project.urls]
 "Homepage" = "https://github.com/graphcore-research/jax-scalify/#readme"
@@ -43,9 +43,15 @@ test = ["pytest"]
 # Relying on the default setuptools.
 # In case of an issue, can use the following options
 # [tool.setuptools]
-# packages = ["jax_scalify", "jax_scalify.core", "jax_scalify.lax", "jax_scalify.ops"]
+# packages = ["jax_scalify", "jax_scalify.core", "jax_scalify.lax", "jax_scalify.ops", "jax_scalify.tree"]
 # [tool.setuptools.packages]
 # find = {namespaces = false}
+
+[tool.setuptools.dynamic]
+version = {attr = "jax_scalify.version.__version__"}
+
+[tool.setuptools_scm]
+version_file = "jax_scalify/version.py"
 
 [tool.pytest.ini_options]
 minversion = "6.0"


### PR DESCRIPTION
Removing old manual setup + using dynamic rule in `pyproject.toml`.